### PR TITLE
Allow Indexes to be named

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -816,11 +816,14 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     protected function getIndexSqlDefinition(Index $index)
     {
         $def = '';
-        if ($index->getType() == Index::UNIQUE) {
-            $def .= ' UNIQUE KEY (`' . implode('`,`', $index->getColumns()) . '`)';
-        } else {
-            $def .= ' KEY (`' . implode('`,`', $index->getColumns()) . '`)';
-        }
+        $unique = ($index->getType() === Index::UNIQUE) ? 'UNIQUE ' : ' ';
+        $def .= vsprintf('%sKEY `%s` (%s)',
+            array(
+                $unique,
+                $index->getName(),
+                '`' . implode('`,`', $index->getColumns()) . '`'
+            )
+        );
         return $def;
     }
 

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -51,6 +51,11 @@ class Index
     protected $type;
     
     /**
+     * @var string 
+     */
+    protected $name = null;
+    
+    /**
      * Sets the index columns.
      *
      * @param array $columns
@@ -95,6 +100,29 @@ class Index
     }
     
     /**
+     * Gets the Index Name
+     * 
+     * @return string
+     */
+    public function getName()
+    {
+        if (null === $this->name) {
+            $this->name = implode('_', $this->columns);
+        }
+        return $this->name;
+    }
+    
+    /**
+     * Sets the Index Name
+     * 
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+    
+    /**
      * Utility method that maps an array of index options to this objects methods.
      *
      * @param array $options Options
@@ -103,7 +131,7 @@ class Index
     public function setOptions($options)
     {
         // Valid Options
-        $validOptions = array('type', 'unique');
+        $validOptions = array('type', 'unique', 'name');
         foreach ($options as $option => $value) {
             if (!in_array($option, $validOptions)) {
                 throw new \RuntimeException('\'' . $option . '\' is not a valid index option.');


### PR DESCRIPTION
This is a quick modification allowing Indexes to be named like so;

```php
$this->table('people')
->addColumn('foreign_id', 'integer')
->addIndex('foreign_id', array('name' =>'people_foreign_id_idx'))
->save();
// expected :
// KEY `people_foreign_id_idx` (`foreign_id`)
```