### PR TITLE
Add MySQL enum support

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -659,7 +659,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'tinyint', 'limit' => 1);
                 break;
             case 'enum':
-                return array('name' => 'enum', 'limit' => "''");
+                return array('name' => 'enum');
                 break;
             default:
                 throw new \RuntimeException('The type: "' . $type . '" is not supported.');

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -22,7 +22,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
- * 
+ *
  * @package    Phinx
  * @subpackage Phinx\Db\Adapter
  */
@@ -51,11 +51,11 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 throw new \RuntimeException('You need to enable the PDO_Mysql extension for Phinx to run properly.');
                 // @codeCoverageIgnoreEnd
             }
-            
+
             $dsn = '';
             $db = null;
             $options = $this->getOptions();
-            
+
             // if port is specified use it, otherwise use the MySQL default
             if (isset($options['port'])) {
                 $dsn = 'mysql:host=' . $options['host'] . ';port=' . $options['port'] . ';dbname=' . $options['name'];
@@ -83,14 +83,14 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             }
 
             $this->setConnection($db);
-            
+
             // Create the schema table if it doesn't already exist
             if (!$this->hasSchemaTable()) {
                 $this->createSchemaTable();
             }
         }
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -98,7 +98,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         $this->connection = null;
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -106,7 +106,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         return true;
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -114,7 +114,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         $this->execute('START TRANSACTION');
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -122,7 +122,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         $this->execute('COMMIT');
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -130,7 +130,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         $this->execute('ROLLBACK');
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -138,7 +138,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         return str_replace('.', '`.`', $this->quoteColumnName($tableName));
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -146,23 +146,23 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     {
         return '`' . str_replace('`', '``', $columnName) . '`';
     }
-    
+
     /**
      * {@inheritdoc}
      */
     public function hasTable($tableName)
     {
         $options = $this->getOptions();
-        
+
         $tables = array();
         $rows = $this->fetchAll(sprintf('SHOW TABLES IN `%s`', $options['name']));
         foreach ($rows as $row) {
             $tables[] = strtolower($row[0]);
         }
-        
+
         return in_array(strtolower($tableName), $tables);
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -176,7 +176,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             'collation' => 'utf8_general_ci'
         );
         $options = array_merge($defaultOptions, $table->getOptions());
-        
+
         // Add the default primary key
         $columns = $table->getPendingColumns();
         if (!isset($options['id']) || (isset($options['id']) && $options['id'] === true)) {
@@ -184,7 +184,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $column->setName('id')
                    ->setType('integer')
                    ->setIdentity(true);
-            
+
             array_unshift($columns, $column);
             $options['primary_key'] = 'id';
 
@@ -198,28 +198,28 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             array_unshift($columns, $column);
             $options['primary_key'] = $options['id'];
         }
-        
+
         // TODO - process table options like collation etc
-        
+
         // process table engine (default to InnoDB)
         $optionsStr = 'ENGINE = InnoDB';
         if (isset($options['engine'])) {
             $optionsStr = sprintf('ENGINE = %s', $options['engine']);
         }
-        
+
         // process table collation
         if (isset($options['collation'])) {
             $charset = explode('_', $options['collation']);
             $optionsStr .= sprintf(' CHARACTER SET %s', $charset[0]);
             $optionsStr .= sprintf(' COLLATE %s', $options['collation']);
         }
-        
+
         $sql = 'CREATE TABLE ';
         $sql .= $this->quoteTableName($table->getName()) . ' (';
         foreach ($columns as $column) {
             $sql .= $this->quoteColumnName($column->getName()) . ' ' . $this->getColumnSqlDefinition($column) . ', ';
         }
-        
+
         // set the primary key(s)
         if (isset($options['primary_key'])) {
             $sql = rtrim($sql);
@@ -235,7 +235,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         } else {
             $sql = substr(rtrim($sql), 0, -1);              // no primary keys
         }
-        
+
         // set the indexes
         $indexes = $table->getIndexes();
         if (!empty($indexes)) {
@@ -260,7 +260,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         $this->execute($sql);
         $this->endCommandTimer();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -271,7 +271,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         $this->execute(sprintf('RENAME TABLE %s TO %s', $this->quoteTableName($tableName), $this->quoteTableName($newTableName)));
         $this->endCommandTimer();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -310,7 +310,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
 
         return $columns;
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -322,10 +322,10 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return true;
             }
         }
-        
+
         return false;
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -337,16 +337,16 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $this->quoteColumnName($column->getName()),
             $this->getColumnSqlDefinition($column)
         );
-        
+
         if ($column->getAfter()) {
             $sql .= ' AFTER ' . $this->quoteColumnName($column->getAfter());
         }
-        
+
         $this->writeCommand('addColumn', array($table->getName(), $column->getName(), $column->getType()));
         $this->execute($sql);
         $this->endCommandTimer();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -359,7 +359,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 $null = ($row['Null'] == 'NO') ? 'NOT NULL' : 'NULL';
                 $extra = ' ' . strtoupper($row['Extra']);
                 $definition = $row['Type'] . ' ' . $null . $extra;
-        
+
                 $this->writeCommand('renameColumn', array($tableName, $columnName, $newColumnName));
                 $this->execute(
                     sprintf('ALTER TABLE %s CHANGE COLUMN %s %s %s',
@@ -372,13 +372,13 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return $this->endCommandTimer();
             }
         }
-        
+
         throw new \InvalidArgumentException(sprintf(
             'The specified column doesn\'t exist: '
             . $columnName
         ));
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -396,7 +396,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         );
         return $this->endCommandTimer();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -413,7 +413,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         );
         return $this->endCommandTimer();
     }
-    
+
     /**
      * Get an array of indexes from a particular table.
      *
@@ -432,7 +432,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         }
         return $indexes;
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -441,20 +441,20 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         if (is_string($columns)) {
             $columns = array($columns); // str to array
         }
-        
+
         $columns = array_map('strtolower', $columns);
         $indexes = $this->getIndexes($tableName);
-        
+
         foreach ($indexes as $index) {
             $a = array_diff($columns, $index['columns']);
             if (empty($a)) {
                 return true;
             }
         }
-        
+
         return false;
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -470,7 +470,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         );
         return $this->endCommandTimer();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -480,11 +480,11 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         if (is_string($columns)) {
             $columns = array($columns); // str to array
         }
-        
+
         $this->writeCommand('dropIndex', array($tableName, $columns));
         $indexes = $this->getIndexes($tableName);
         $columns = array_map('strtolower', $columns);
-        
+
         foreach ($indexes as $indexName => $index) {
             $a = array_diff($columns, $index['columns']);
             if (empty($a)) {
@@ -581,9 +581,9 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         if (is_string($columns)) {
             $columns = array($columns); // str to array
         }
-        
+
         $this->writeCommand('dropForeignKey', array($tableName, $columns));
-        
+
         if ($constraint) {
             $this->execute(
                 sprintf('ALTER TABLE %s DROP FOREIGN KEY %s',
@@ -613,7 +613,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         }
         return $this->endCommandTimer();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -657,6 +657,9 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 break;
             case 'boolean':
                 return array('name' => 'tinyint', 'limit' => 1);
+                break;
+            case 'enum':
+                return array('name' => 'enum', 'limit' => "''");
                 break;
             default:
                 throw new \RuntimeException('The type: "' . $type . '" is not supported.');
@@ -731,7 +734,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         $this->startCommandTimer();
         $this->writeCommand('createDatabase', array($name));
         $charset = isset($options['charset']) ? $options['charset'] : 'utf8';
-        
+
         if (isset($options['collation'])) {
             $this->execute(sprintf(
                 'CREATE DATABASE `%s` DEFAULT CHARACTER SET `%s` COLLATE `%s`', $name, $charset, $options['collation']
@@ -741,7 +744,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         }
         return $this->endCommandTimer();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -753,16 +756,16 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 $name
             )
         );
-        
+
         foreach ($rows as $row) {
             if (!empty($row)) {
                 return true;
             }
         }
-        
+
         return false;
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -773,7 +776,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         $this->execute(sprintf('DROP DATABASE IF EXISTS `%s`', $name));
         return $this->endCommandTimer();
     }
-    
+
     /**
      * Gets the MySQL Column Definition for a Column object.
      *
@@ -809,7 +812,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
 
         return $def;
     }
-    
+
     /**
      * Gets the MySQL Index Definition for an Index object.
      *

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -22,7 +22,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
- * 
+ *
  * @package    Phinx
  * @subpackage Phinx\Db\Adapter
  */
@@ -44,12 +44,12 @@ abstract class PdoAdapter implements AdapterInterface
      * @var array
      */
     protected $options;
-    
+
     /**
      * @var OutputInterface
      */
     protected $output;
-    
+
     /**
      * @var string
      */
@@ -79,7 +79,7 @@ abstract class PdoAdapter implements AdapterInterface
             $this->setOutput($output);
         }
     }
-    
+
     /**
      * Sets the adapter options.
      *
@@ -95,7 +95,7 @@ abstract class PdoAdapter implements AdapterInterface
 
         return $this;
     }
-    
+
     /**
      * Gets the adapter options.
      *
@@ -114,7 +114,7 @@ abstract class PdoAdapter implements AdapterInterface
         $this->output = $output;
         return $this;
     }
-    
+
    /**
      * {@inheritdoc}
      */
@@ -126,7 +126,7 @@ abstract class PdoAdapter implements AdapterInterface
         }
         return $this->output;
     }
-    
+
     /**
      * Sets the schema table name.
      *
@@ -138,7 +138,7 @@ abstract class PdoAdapter implements AdapterInterface
         $this->schemaTableName = $schemaTableName;
         return $this;
     }
-    
+
     /**
      * Gets the schema table name.
      *
@@ -148,7 +148,7 @@ abstract class PdoAdapter implements AdapterInterface
     {
         return $this->schemaTableName;
     }
-    
+
     /**
      * Sets the database connection.
      *
@@ -160,7 +160,7 @@ abstract class PdoAdapter implements AdapterInterface
         $this->connection = $connection;
         return $this;
     }
-    
+
     /**
      * Gets the database connection
      *
@@ -240,7 +240,7 @@ abstract class PdoAdapter implements AdapterInterface
                         $outArr[] = '[' . implode(', ', $arg)  . ']';
                         continue;
                     }
-                
+
                     $outArr[] = '\'' . $arg . '\'';
                 }
                 return $this->getOutput()->writeln(' -- ' . $command . '(' . implode(', ', $outArr) . ')');
@@ -248,21 +248,21 @@ abstract class PdoAdapter implements AdapterInterface
             $this->getOutput()->writeln(' -- ' . $command);
         }
     }
-     
+
     /**
      * {@inheritdoc}
      */
     public function connect()
     {
     }
-     
+
     /**
      * {@inheritdoc}
      */
     public function disconnect()
     {
     }
-     
+
     /**
      * {@inheritdoc}
      */
@@ -270,7 +270,7 @@ abstract class PdoAdapter implements AdapterInterface
     {
         return $this->getConnection()->exec($sql);
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -278,7 +278,7 @@ abstract class PdoAdapter implements AdapterInterface
     {
         return $this->getConnection()->query($sql);
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -287,7 +287,7 @@ abstract class PdoAdapter implements AdapterInterface
         $result = $this->query($sql);
         return $result->fetch();
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -300,18 +300,18 @@ abstract class PdoAdapter implements AdapterInterface
         }
         return $rows;
     }
-    
+
     /**
      * {@inheritdoc}
      */
     public function getVersions()
     {
         $versions = array();
-        
+
         $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY version ASC', $this->getSchemaTableName()));
         return array_map(function($v) {return $v['version'];}, $rows);
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -341,13 +341,13 @@ abstract class PdoAdapter implements AdapterInterface
                 $this->getSchemaTableName(),
                 $migration->getVersion()
             );
-            
+
             $this->query($sql);
         }
 
         return $this;
     }
-    
+
     /**
      * Describes a database table.
      *
@@ -357,7 +357,7 @@ abstract class PdoAdapter implements AdapterInterface
     public function describeTable($tableName)
     {
         $options = $this->getOptions();
-        
+
         // mysql specific
         $sql = sprintf(
             'SELECT *'
@@ -367,10 +367,10 @@ abstract class PdoAdapter implements AdapterInterface
             $options['name'],
             $tableName
         );
-        
+
         return $this->fetchRow($sql);
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -378,7 +378,7 @@ abstract class PdoAdapter implements AdapterInterface
     {
         return $this->hasTable($this->getSchemaTableName());
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -388,7 +388,7 @@ abstract class PdoAdapter implements AdapterInterface
             $options = array(
                 'id' => false
             );
-            
+
             $table = new \Phinx\Db\Table($this->getSchemaTableName(), $options, $this);
             $table->addColumn('version', 'biginteger', array('limit' => 14))
                   ->addColumn('start_time', 'timestamp')
@@ -407,7 +407,7 @@ abstract class PdoAdapter implements AdapterInterface
         $options = $this->getOptions();
         return $options['adapter'];
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -426,7 +426,8 @@ abstract class PdoAdapter implements AdapterInterface
             'time',
             'date',
             'binary',
-            'boolean'
+            'boolean',
+            'enum'
         );
     }
 }

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -385,11 +385,11 @@ class Column
         }
     }
 
-    protected function arrayToSql($array) {
+    protected function arrayToSql(Array $array) {
 
-        if (is_array($array)) {
+        if (!empty($array)) {
             $arraySql = "'" . implode("','", $array) . "'";
-        } elseif (is_null($array)) {
+        } else {
             $arraySql = "''";
         }
 

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -22,7 +22,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
- * 
+ *
  * @package    Phinx
  * @subpackage Phinx\Db
  */
@@ -38,27 +38,27 @@ class Column
      * @var string
      */
     protected $name;
-    
+
     /**
      * @var string
      */
     protected $type;
-    
+
     /**
      * @var integer
      */
     protected $limit = null;
-    
+
     /**
      * @var boolean
      */
     protected $null = false;
-    
+
     /**
      * @var mixed
      */
     protected $default = null;
-    
+
     /**
      * @var boolean
      */
@@ -73,7 +73,7 @@ class Column
      * @var integer
      */
     protected $scale;
-    
+
     /**
      * @var string
      */
@@ -100,7 +100,7 @@ class Column
         $this->name = $name;
         return $this;
     }
-    
+
     /**
      * Gets the column name.
      *
@@ -110,7 +110,7 @@ class Column
     {
         return $this->name;
     }
-    
+
     /**
      * Sets the column type.
      *
@@ -122,7 +122,7 @@ class Column
         $this->type = $type;
         return $this;
     }
-    
+
     /**
      * Gets the column type.
      *
@@ -132,7 +132,7 @@ class Column
     {
         return $this->type;
     }
-    
+
     /**
      * Sets the column limit.
      *
@@ -141,10 +141,15 @@ class Column
      */
     public function setLimit($limit)
     {
-        $this->limit = $limit;
+        if (!is_array($limit)) {
+            $this->limit = $limit;
+        } else {
+            $this->limit = $this->arrayToSql($limit);
+        }
+
         return $this;
     }
-    
+
     /**
      * Gets the column limit.
      *
@@ -154,7 +159,7 @@ class Column
     {
         return $this->limit;
     }
-    
+
     /**
      * Sets whether the column allows nulls.
      *
@@ -166,7 +171,7 @@ class Column
         $this->null = (bool) $null;
         return $this;
     }
-    
+
     /**
      * Gets whether the column allows nulls.
      *
@@ -176,7 +181,7 @@ class Column
     {
         return $this->null;
     }
-    
+
     /**
      * Does the column allow nulls?
      *
@@ -186,7 +191,7 @@ class Column
     {
         return $this->getNull();
     }
-    
+
     /**
      * Sets the default column value.
      *
@@ -201,7 +206,7 @@ class Column
         $this->default = $default;
         return $this;
     }
-    
+
     /**
      * Gets the default column value.
      *
@@ -211,7 +216,7 @@ class Column
     {
         return $this->default;
     }
-    
+
     /**
      * Sets whether or not the column is an identity column.
      *
@@ -223,7 +228,7 @@ class Column
         $this->identity = $identity;
         return $this;
     }
-    
+
     /**
      * Gets whether or not the column is an identity column.
      *
@@ -233,7 +238,7 @@ class Column
     {
         return $this->identity;
     }
-    
+
     /**
      * Is the column an identity column?
      *
@@ -243,7 +248,7 @@ class Column
     {
         return $this->getIdentity();
     }
-    
+
     /**
      * Sets the name of the column to add this column after.
      *
@@ -255,7 +260,7 @@ class Column
         $this->after = $after;
         return $this;
     }
-    
+
     /**
      * Returns the name of the column to add this column after.
      *
@@ -299,7 +304,7 @@ class Column
         $this->precision = $precision;
         return $this;
     }
-    
+
     /**
      * Gets the column precision for decimal.
      *
@@ -321,7 +326,7 @@ class Column
         $this->scale = $scale;
         return $this;
     }
-    
+
     /**
      * Gets the column scale for decimal.
      *
@@ -368,15 +373,26 @@ class Column
             if (!in_array($option, $validOptions)) {
                 throw new \RuntimeException('\'' . $option . '\' is not a valid column option.');
             }
-            
+
             // proxy length -> limit
             if (strtolower($option) == 'length') {
                 $this->setLimit($value);
                 continue;
             }
-            
+
             $method = 'set' . ucfirst($option);
             $this->$method($value);
         }
+    }
+
+    protected function arrayToSql($array) {
+
+        if (is_array($array)) {
+            $arraySql = "'" . implode("','", $array) . "'";
+        } elseif (is_null($array)) {
+            $arraySql = "''";
+        }
+
+        return $arraySql;
     }
 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -11,7 +11,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
      * @var \Phinx\Db\Adapter\MysqlAdapter
      */
     private $adapter;
-    
+
     public function setUp()
     {
         $options = array(
@@ -30,17 +30,17 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         // leave the adapter in a disconnected state for each test
         $this->adapter->disconnect();
     }
-    
+
     public function tearDown()
     {
         unset($this->adapter);
     }
-    
+
     public function testConnection()
     {
         $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
     }
-    
+
     public function testConnectionWithoutPort()
     {
         $options = $this->adapter->getOptions();
@@ -48,7 +48,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->adapter->setOptions($options);
         $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
     }
-    
+
     public function testConnectionWithInvalidCredentials()
     {
         $options = array(
@@ -58,7 +58,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
             'user' => 'invaliduser',
             'pass' => 'invalidpass'
         );
-        
+
         try {
             $adapter = new MysqlAdapter($options, new NullOutput());
             $adapter->connect();
@@ -69,7 +69,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
             $this->assertRegExp('/There was a problem connecting to the database/', $e->getMessage());
         }
     }
-    
+
     public function testCreatingTheSchemaTableOnConnect()
     {
         $this->adapter->connect();
@@ -80,17 +80,17 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->adapter->connect();
         $this->assertTrue($this->adapter->hasTable($this->adapter->getSchemaTableName()));
     }
-    
+
     public function testQuoteTableName()
     {
         $this->assertEquals('`test_table`', $this->adapter->quoteTableName('test_table'));
     }
-    
+
     public function testQuoteColumnName()
     {
         $this->assertEquals('`test_column`', $this->adapter->quoteColumnName('test_column'));
     }
-    
+
     public function testCreateTable()
     {
         $table = new \Phinx\Db\Table('ntable', array(), $this->adapter);
@@ -122,7 +122,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete();
         //$this->adapter->createTable('ntable', )
     }
-    
+
     public function testCreateTableWithNoPrimaryKey()
     {
         $options = array(
@@ -133,7 +133,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
               ->save();
         $this->assertFalse($this->adapter->hasColumn('atable', 'id'));
     }
-    
+
     public function testCreateTableWithMultiplePrimaryKeys()
     {
         $options = array(
@@ -162,7 +162,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->adapter->hasIndex('table1', array('email', 'user_email')));
         $this->assertFalse($this->adapter->hasIndex('table1', array('email', 'user_name')));
     }
-    
+
     public function testCreateTableWithUniqueIndexes()
     {
         $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
@@ -172,12 +172,12 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->adapter->hasIndex('table1', array('email')));
         $this->assertFalse($this->adapter->hasIndex('table1', array('email', 'user_email')));
     }
-    
+
     public function testCreateTableWithMultiplePKsAndUniqueIndexes()
     {
         $this->markTestIncomplete();
     }
-    
+
     public function testCreateTableWithMyISAMEngine()
     {
         $table = new \Phinx\Db\Table('ntable', array('engine' => 'MyISAM'), $this->adapter);
@@ -187,7 +187,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $row = $this->adapter->fetchRow(sprintf('SHOW TABLE STATUS WHERE Name = "%s"', 'ntable'));
         $this->assertEquals('MyISAM', $row['Engine']);
     }
-    
+
     public function testCreateTableWithLatin1Collate()
     {
         $table = new \Phinx\Db\Table('latin1_table', array('collation' => 'latin1_general_ci'), $this->adapter);
@@ -197,7 +197,56 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $row = $this->adapter->fetchRow(sprintf('SHOW TABLE STATUS WHERE Name = "%s"', 'latin1_table'));
         $this->assertEquals('latin1_general_ci', $row['Collation']);
     }
-    
+
+    public function testCreateTableWithMultipleValueEnum()
+    {
+        $table = new \Phinx\Db\Table('dogs', array(), $this->adapter);
+        $table->addColumn('breed', 'enum', array( 'limit' => array('Australian Shepherd', 'Pembroke Welsh Corgi', 'Collie')))
+              ->save();
+
+        $this->assertTrue($this->adapter->hasTable('dogs'));
+        $this->assertTrue($this->adapter->hasColumn('dogs', 'breed'));
+
+        $row = $this->adapter->fetchRow("SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = 'dogs' AND COLUMN_NAME = 'breed'");
+        $this->assertEquals("enum('Australian Shepherd','Pembroke Welsh Corgi','Collie')", $row['COLUMN_TYPE']);
+    }
+
+    public function testCreateTableWithSingleValueEnum()
+    {
+        $table = new \Phinx\Db\Table('dogs', array(), $this->adapter);
+        $table->addColumn('breed', 'enum', array( 'limit' => array('German Shepherd')))
+              ->save();
+
+        $this->assertTrue($this->adapter->hasTable('dogs'));
+        $this->assertTrue($this->adapter->hasColumn('dogs', 'breed'));
+
+        $row = $this->adapter->fetchRow("SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = 'dogs' AND COLUMN_NAME = 'breed'");
+        $this->assertEquals("enum('German Shepherd')", $row['COLUMN_TYPE']);
+    }
+
+    public function testCreateTableWithBlankArrayEnum()
+    {
+        $table = new \Phinx\Db\Table('dogs', array(), $this->adapter);
+        $table->addColumn('breed', 'enum', array('limit' => array()))
+              ->save();
+
+        $this->assertTrue($this->adapter->hasTable('dogs'));
+        $this->assertTrue($this->adapter->hasColumn('dogs', 'breed'));
+
+        $row = $this->adapter->fetchRow("SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = 'dogs' AND COLUMN_NAME = 'breed'");
+        $this->assertEquals("enum('')", $row['COLUMN_TYPE']);
+    }
+
+
+    public function testCreateTableWithBlankEnum()
+    {
+        $this->setExpectedException('PDOException');
+
+        $table = new \Phinx\Db\Table('dogs', array(), $this->adapter);
+        $table->addColumn('breed', 'enum')
+              ->save();
+    }
+
     public function testRenameTable()
     {
         $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
@@ -208,7 +257,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->adapter->hasTable('table1'));
         $this->assertTrue($this->adapter->hasTable('table2'));
     }
-    
+
     public function testAddColumn()
     {
         $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
@@ -253,7 +302,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM table1');
         $this->assertNull($rows[1]['Default']);
     }
-    
+
     public function testRenameColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
@@ -265,13 +314,13 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->adapter->hasColumn('t', 'column1'));
         $this->assertTrue($this->adapter->hasColumn('t', 'column2'));
     }
-    
+
     public function testRenamingANonExistentColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
         $table->addColumn('column1', 'string')
               ->save();
-        
+
         try {
             $this->adapter->renameColumn('t', 'column2', 'column1');
             $this->fail('Expected the adapter to throw an exception');
@@ -281,7 +330,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals('The specified column doesn\'t exist: column2', $e->getMessage());
         }
     }
-    
+
     public function testChangeColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
@@ -341,7 +390,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM t');
         $this->assertNull($rows[1]['Default']);
     }
-    
+
     public function testDropColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
@@ -377,7 +426,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($pendingColumns[$i], $columns[$i+1]);
         }
     }
-    
+
     public function testAddIndex()
     {
         $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
@@ -388,7 +437,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
               ->save();
         $this->assertTrue($table->hasIndex('email'));
     }
-    
+
     public function testDropIndex()
     {
         // single column index
@@ -399,7 +448,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($table->hasIndex('email'));
         $this->adapter->dropIndex($table->getName(), 'email');
         $this->assertFalse($table->hasIndex('email'));
-        
+
         // multiple column index
         $table2 = new \Phinx\Db\Table('table2', array(), $this->adapter);
         $table2->addColumn('fname', 'string')
@@ -445,13 +494,13 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->adapter->dropForeignKey($table->getName(), array('ref_table_id'));
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), array('ref_table_id')));
     }
-    
+
     public function testHasDatabase()
     {
         $this->assertFalse($this->adapter->hasDatabase('fake_database_name'));
         $this->assertTrue($this->adapter->hasDatabase(TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE));
     }
-    
+
     public function testDropDatabase()
     {
         $this->assertFalse($this->adapter->hasDatabase('temp_phinx_database'));


### PR DESCRIPTION
This PR allows a user to create enum columns using MySQL

Usage is as follows:

```
// Normal usage - pass a PHP array in for the 'limit' option
$this->addColumn('column_name', 'enum', array('limit' => array('value1', 'value2'))

// or create a blank enum (not sure why you would do this, but it is supported since MySQL supports it)
$this->addColumn('column_name', 'enum', array('limit' => array())

// creating an enum column and not specifying a limit will throw a PDOException
$this->addColumn('column_name', 'enum')
```