### PR TITLE
Support prepared statements

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -147,7 +147,7 @@ Executing Queries
 
 Queries can be executed with the ``execute()`` and ``query()`` methods. The
 ``execute()`` method returns the number of affected rows whereas the
-``query()`` method returns the result as an array.
+``query()`` method returns the result as an array (or PDOStatement).
 
 .. code-block:: php
         
@@ -167,6 +167,11 @@ Queries can be executed with the ``execute()`` and ``query()`` methods. The
 
                 // query()
                 $rows = $this->query('SELECT * FROM users'); // returns the result as an array
+
+                // Supports prepared statements as well
+                $this->execute('DELETE FROM users WHERE id = :user_id', array(
+                  ':user_id' => 5
+                ));
             }
 
             /**

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -263,23 +263,47 @@ abstract class PdoAdapter implements AdapterInterface
     public function disconnect()
     {
     }
-     
+
     /**
-     * {@inheritdoc}
+     * Executes a SQL statement and returns the number of affected rows.
+     *
+     * If PDO::ATTR_ERRMODE is set to PDO::ERRMODE_SILENT this method would
+     * return boolean false on failure. Otherwise it would throw an exception
+     * or a warning.
+     *
+     * @param string $sql SQL
+     * @param array $params Parameters to bind for prepared statements
+     * @return int|false The number of rows affected or false on failure
+     * @uses PDOStatement::prepare
+     * @uses PDOStatement::execute
      */
-    public function execute($sql)
+    public function execute($sql, array $params = array())
     {
-        return $this->getConnection()->exec($sql);
+        $pdoStatement = $this->getConnection()->prepare($sql);
+
+        if ($pdoStatement and $pdoStatement->execute($params)) {
+            return $pdoStatement->rowCount();
+        }
+
+        return false;
     }
-    
+
     /**
-     * {@inheritdoc}
+     * Executes a SQL statement and returns the result as a PDOStatement
+     *
+     * @param string $sql SQL
+     * @param array $params Parameters to bind for prepared statements
+     * @return PDOStatement
      */
-    public function query($sql)
+    public function query($sql, array $params = array())
     {
-        return $this->getConnection()->query($sql);
+        $pdoStatement = $this->getConnection()->prepare($sql);
+
+        $pdoStatement->execute($params);
+
+        return $pdoStatement;
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Phinx/Db/Adapter/ProxyAdapter.php
+++ b/src/Phinx/Db/Adapter/ProxyAdapter.php
@@ -155,21 +155,29 @@ class ProxyAdapter implements AdapterInterface
     }
     
     /**
-     * {@inheritdoc}
+     * Executes a SQL statement and returns the number of affected rows.
+     *
+     * @param string $sql SQL
+     * @param array $params Parameters to bind for prepared statements
+     * @return int The number of rows affected
      */
-    public function execute($sql)
+    public function execute($sql, array $params = array())
     {
-        return $this->getAdapter()->execute($sql);
+        return $this->getAdapter()->execute($sql, $params);
     }
-    
+
     /**
-     * {@inheritdoc}
+     * Executes a SQL statement and returns the result as a PDOStatement
+     *
+     * @param string $sql SQL
+     * @param array $params Parameters to bind for prepared statements
+     * @return PDOStatement
      */
-    public function query($sql)
+    public function query($sql, array $params = array())
     {
-        return $this->getAdapter()->query($sql);
+        return $this->getAdapter()->query($sql, $params);
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -134,17 +134,17 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * {@inheritdoc}
      */
-    public function execute($sql)
+    public function execute($sql, array $params = array())
     {
-        return $this->getAdapter()->execute($sql);
+        return $this->getAdapter()->execute($sql, $params);
     }
     
     /**
      * {@inheritdoc}
      */
-    public function query($sql)
+    public function query($sql, array $params = array())
     {
-        return $this->getAdapter()->query($sql);
+        return $this->getAdapter()->query($sql, $params);
     }
     
     /**

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -107,17 +107,19 @@ interface MigrationInterface
      * Executes a SQL statement and returns the number of affected rows.
      * 
      * @param string $sql SQL
+     * @param array $params Parameters to bind for prepared statements
      * @return int
      */
-    public function execute($sql);
+    public function execute($sql, array $params = array());
     
     /**
      * Executes a SQL statement and returns the result as an array. 
      *
      * @param string $sql SQL
+     * @param array $params Parameters to bind for prepared statements
      * @return array
      */
-    public function query($sql);
+    public function query($sql, array $params = array());
     
     /**
      * Executes a query and returns only one row as an array.


### PR DESCRIPTION
Simple support using a second argument `$params` to:
 - `PdoAdapter::execute()`
 - `PdoAdapter::query()`
 - `ProxyAdapter::execute()`
 - `ProxyAdapter::query()`
 - `MigrationInterface::execute()`
 - `MigrationInterface::query()`
 - `AbstractMigration::execute()`
 - `AbstractMigration::query()`

Closes #203