### PR TITLE
Add --colors to status

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -44,6 +44,7 @@ class Migrate extends AbstractCommand
         parent::configure();
 
         $this->addOption('--environment', '-e', InputArgument::OPTIONAL, 'The target environment');
+        $this->addOption('--colors', null, InputArgument::OPTIONAL, 'Enforce coloring');
 
         $this->setName('migrate')
              ->setDescription('Migrate the database')
@@ -83,6 +84,10 @@ EOT
         $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
         $output->writeln('<info>using database</info> ' . $envOptions['name']);
 
+        $enforceColors = $input->getOption('colors');
+        if(filter_var($enforceColors,FILTER_VALIDATE_BOOLEAN)){
+          $output->setDecorated(true);
+        }
         // run the migrations
         $start = microtime(true);
         $this->getManager()->migrate($environment, $version);

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -44,6 +44,7 @@ class Rollback extends AbstractCommand
         parent::configure();
          
         $this->addOption('--environment', '-e', InputArgument::OPTIONAL, 'The target environment');
+        $this->addOption('--colors', null, InputArgument::OPTIONAL, 'Enforce coloring');
         
         $this->setName('rollback')
              ->setDescription('Rollback the last or to a specific migration')
@@ -82,7 +83,11 @@ EOT
         $envOptions = $this->getConfig()->getEnvironment($environment);
         $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
         $output->writeln('<info>using database</info> ' . $envOptions['name']);
-        
+
+        $enforceColors = $input->getOption('colors');
+        if(filter_var($enforceColors,FILTER_VALIDATE_BOOLEAN)){
+          $output->setDecorated(true);
+        }
         // rollback the specified environment
         $start = microtime(true);
         $this->getManager()->rollback($environment, $version);

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -81,7 +81,6 @@ EOT
         }
         $enforceColors = $input->getOption('colors');
         if(filter_var($enforceColors,FILTER_VALIDATE_BOOLEAN)){
-          $output->writeln('<info>enforce colors</info>');
           $output->setDecorated(true);
         }
         

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -44,6 +44,7 @@ class Status extends AbstractCommand
         parent::configure();
          
         $this->addOption('--environment', '-e', InputArgument::OPTIONAL, 'The target environment');
+        $this->addOption('--colors', null, InputArgument::OPTIONAL, 'Enforce coloring');
          
         $this->setName('status')
              ->setDescription('Show migration status')
@@ -65,7 +66,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->bootstrap($input, $output);
-        
+
         $environment = $input->getOption('environment');
         $format = $input->getOption('format');
         
@@ -77,6 +78,11 @@ EOT
         }
         if (null != $format) {
             $output->writeln('<info>using format</info> ' . $format);
+        }
+        $enforceColors = $input->getOption('colors');
+        if(filter_var($enforceColors,FILTER_VALIDATE_BOOLEAN)){
+          $output->writeln('<info>enforce colors</info>');
+          $output->setDecorated(true);
         }
         
         // print the status

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -99,4 +99,27 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
         $commandTester->execute(array('command' => $command->getName()));
         $this->assertRegExp('/using database development/', $commandTester->getDisplay());
     }
+
+    public function testColorsSpecified()
+    {
+      $application = new \Phinx\Console\PhinxApplication('testing');
+      $application->add(new Migrate());
+
+      // setup dependencies
+      $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+      $command = $application->find('migrate');
+
+      // mock the manager class
+      $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+      $managerStub->expects($this->once())
+        ->method('migrate');
+
+      $command->setConfig($this->config);
+      $command->setManager($managerStub);
+
+      $commandTester = new CommandTester($command);
+      $commandTester->execute(array('command' => $command->getName(), '--colors' => 'true'));
+      $this->assertTrue($commandTester->getOutput()->isDecorated());
+    }
 }

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -99,4 +99,27 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $commandTester->execute(array('command' => $command->getName()));
         $this->assertRegExp('/using database development/', $commandTester->getDisplay());
     }
+
+    public function testColorsSpecified()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Rollback());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub->expects($this->once())
+          ->method('rollback');
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '--colors' => 'true'));
+        $this->assertTrue($commandTester->getOutput()->isDecorated());
+    }
 }

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -99,4 +99,28 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $commandTester->execute(array('command' => $command->getName(), '--format' => 'json'));
         $this->assertRegExp('/using format json/', $commandTester->getDisplay());
     }
+
+    public function testColorsSpecified()
+    {
+      $application = new \Phinx\Console\PhinxApplication('testing');
+      $application->add(new Status());
+
+      // setup dependencies
+      $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+      $command = $application->find('status');
+
+      // mock the manager class
+      $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+      $managerStub->expects($this->once())
+        ->method('printStatus');
+
+      $command->setConfig($this->config);
+      $command->setManager($managerStub);
+
+      $commandTester = new CommandTester($command);
+      $commandTester->execute(array('command' => $command->getName(), '--colors' => 'true'));
+      $this->assertRegExp('/enforce colors/', $commandTester->getDisplay());
+      $this->assertTrue($commandTester->getOutput()->isDecorated());
+    }
 }

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -120,7 +120,6 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
       $commandTester = new CommandTester($command);
       $commandTester->execute(array('command' => $command->getName(), '--colors' => 'true'));
-      $this->assertRegExp('/enforce colors/', $commandTester->getDisplay());
       $this->assertTrue($commandTester->getOutput()->isDecorated());
     }
 }


### PR DESCRIPTION
In case Symfony console do not detect a color capable stream, enforce
coloring for the output

Use case : Phing task