### PR TITLE
Implemented fake command

### DIFF
--- a/src/Phinx/Console/Command/Fake.php
+++ b/src/Phinx/Console/Command/Fake.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2014 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Console
+ */
+namespace Phinx\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Fake extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
+
+        $this->setName('fake')
+            ->setDescription('Fake an exists migration')
+            ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number, which will be faked')
+            ->setHelp(sprintf(
+                '%sFakes an exists database migration (set "up" status without executing)%s',
+                PHP_EOL,
+                PHP_EOL
+            ));
+    }
+
+    /**
+     * Fake a migration in database
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->bootstrap($input, $output);
+
+        $version = $input->getOption('target');
+        $environment = $input->getOption('environment');
+
+        $output->writeln('<info>using environment</info> ' . $environment);
+
+        $envOptions = $this->getConfig()->getEnvironment($environment);
+        $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
+        $output->writeln('<info>using database</info> ' . $envOptions['name']);
+
+        // rollback the specified environment
+        $start = microtime(true);
+        $this->getManager()->fake($environment, $version);
+        $end = microtime(true);
+
+        $output->writeln('');
+        $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+    }
+}

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -56,6 +56,7 @@ class PhinxApplication extends Application
         $this->add(new Command\Migrate());
         $this->add(new Command\Rollback());
         $this->add(new Command\Status());
+        $this->add(new Command\Fake());
         $this->add(new Command\Test());
     }
      

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -273,6 +273,37 @@ class Manager
             }
         }
     }
+
+    /**
+     * Fake a migration in chosen environment
+     * (set "up" status without executing)
+     *
+     * @param string $environment
+     * @param string $version
+     */
+    public function fake($environment, $version)
+    {
+        $migrations = $this->getMigrations();
+        $env = $this->getEnvironment($environment);
+        $versions = $env->getVersions();
+
+        // check that version and file exist
+        if (!isset($migrations[$version])) {
+            $this->getOutput()->writeln("<error>Version ($version) can't be found</error>");
+            return;
+        }
+
+        // check that migration doesn't have status "up" in current environment
+        if (in_array($version, $versions)) {
+            $this->getOutput()->writeln("<error>Target version ($version) already up</error>");
+            return;
+        }
+
+        $migration = $migrations[$version];
+
+        $time = date('Y-m-d H:i:s', time());
+        $env->getAdapter()->migrated($migration, MigrationInterface::UP, $time, $time);
+    }
     
     /**
      * Sets the environments.


### PR DESCRIPTION
Fake a migration in a chosen environment (set "up" status without executing).

For example, SQL code inside FirstMigration will not be executed after this commands:

```sh
$ bin/phinx status -e development
Phinx by Rob Morgan. version 0.3.6

using config file ./phinx.yml
using config parser yaml
using migration path /%path%/migrations
using environment development

 Status  Migration ID    Migration Name
-----------------------------------------
   down  20140703180511  FirstMigration
   down  20140703180516  SecondMigration

$ bin/phinx fake -e development -t 20140703180511
Phinx by Rob Morgan. version 0.3.6

using config file ./phinx.yml
using config parser yaml
using migration path /%path%/migrations
using environment development
using adapter mysql
using database phinx

All Done. Took 0.0133s

Status  Migration ID    Migration Name
-----------------------------------------
     up  20140703180511  FirstMigration
   down  20140703180516  SecondMigration
```




