### PR TITLE
Allow to use one manager to module based migrations

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -116,3 +116,24 @@ When running Phinx from the command line, you may specify a configuration file u
     );
 
 Phinx auto-detects which language parser to use for files with ``*.yml`` and ``*.php`` extensions. The appropriate parser may also be specified via the ``--parser`` and ``-p`` parameters. Anything other than ``"php"`` is treated as YAML.
+
+Running module based migrations
+-------------------------------
+
+You can run module based migrations with one instance of ``\Phinx\Migration\Manager``. 
+
+.. code-block:: php
+
+   public function install()
+   {
+      $config = $this->getPhinxConfig();
+      $environment = ($config->getEnvironment('module_migrate'));
+      $migrationTable = $environment['default_migration_table'];
+      $this->manager->setConfig($config);
+      $this->manager->switchSchemaTableName('module_migrate', $migrationTable);
+   
+      // migrate to the latest version
+      $this->manager->migrate('module_migrate');
+      $this->manager->reset();
+   }
+

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -148,6 +148,21 @@ abstract class PdoAdapter implements AdapterInterface
     {
         return $this->schemaTableName;
     }
+
+    /**
+     * Switchs the schema table name the to new one
+     * Creates the new table if given table does not exist yet
+     *
+     * @param $schemaTableName
+     */
+    public function switchSchemaTableName($schemaTableName)
+    {
+        $this->setSchemaTableName($schemaTableName);
+
+        if (!$this->hasSchemaTable()) {
+            $this->createSchemaTable();
+        }
+    }
     
     /**
      * Sets the database connection.

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -449,4 +449,28 @@ class Manager
     {
         return $this->config;
     }
+
+    /**
+     * Resets array with migrations to null what allows to load another migration
+     *
+     * @return void
+     */
+    public function reset()
+    {
+        $this->migrations = null;
+    }
+
+    /**
+     * Creates the new schema table, if given table is not the same as currently used one
+     *
+     * @param String $env The name of used environment
+     * @param String $newSchemaTableName The name of new schema table
+     */
+    public function switchSchemaTableName($env, $newSchemaTableName)
+    {
+        $currentSchemaTablaName = $this->getEnvironment($env)->getAdapter()->getSchemaTableName();
+        if ($newSchemaTableName != $currentSchemaTablaName) {
+            $this->getEnvironment($env)->getAdapter()->switchSchemaTableName($newSchemaTableName);
+        }
+    }
 }

--- a/tests/Phinx/Migration/_files/resetmanagerandswitchscheme/20120111235330_first_migration_name.php
+++ b/tests/Phinx/Migration/_files/resetmanagerandswitchscheme/20120111235330_first_migration_name.php
@@ -1,0 +1,22 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class FirstMigrationName extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        // do nothing
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        // do nothing
+    }
+}

--- a/tests/Phinx/Migration/_files/resetmanagerandswitchscheme/20120111235331_second_migration_name.php
+++ b/tests/Phinx/Migration/_files/resetmanagerandswitchscheme/20120111235331_second_migration_name.php
@@ -1,0 +1,22 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class SecondMigrationName extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        // do nothing
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        // do nothing
+    }
+}


### PR DESCRIPTION
I have few modules. Each of them should have own migrations. When I create manager instance for each module it tooks too long time. I needed change schema table on the fly per each module.

```php
    public function install()
    {
        $config = $this->getPhinxConfig();
        $environment = $config->getEnvironment('module_migrate');
        $migrationTable = $environment['default_migration_table'];
        $this->manager->setConfig($config);
        $this->manager->switchSchemaTableName('module_migrate', $migrationTable);

        // migrate to the latest version
        $this->manager->migrate('module_migrate');
        $this->manager->reset();
    }
```