### PR TITLE
Change the way to get migration template on Create and Abstract commands

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -242,4 +242,14 @@ abstract class AbstractCommand extends Command
             $this->setManager($manager);
         }
     }
+
+    /**
+     * Returns the migration template
+     *
+     * @return string Migration template
+     */
+    protected  function getMigrationTemplate()
+    {
+        return file_get_contents(dirname(__FILE__) . '/../../Migration/Migration.template.php.dist');
+    }
 }

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -97,7 +97,7 @@ class Create extends AbstractCommand
         }
         
         // load the migration template
-        $contents = file_get_contents(dirname(__FILE__) . '/../../Migration/Migration.template.php.dist');
+        $contents = $this->getMigrationTemplate();
         
         // inject the class name
         $contents = str_replace('$className', $className, $contents);


### PR DESCRIPTION
Currently I need to use a custom migration template for the create command. With this change I can override this method to return my custom template.