### PR TITLE
Support PostgreSql Array type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ php:
   - 5.5
   - 5.6
   - hhvm
+addons:
+  postgresql: "9.2"
 env:
   - TESTS_PHINX_DB_ADAPTER_POSTGRES_ENABLED=true
 script:

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -31,6 +31,7 @@ namespace Phinx\Db\Adapter;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Phinx\Db\Table;
+use Phinx\Db\Table\Column;
 use Phinx\Migration\MigrationInterface;
 
 /**
@@ -418,5 +419,12 @@ abstract class PdoAdapter implements AdapterInterface
             'linestring',
             'polygon',
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkColumnType(Column $column) {
+        return in_array($column->getType(), $this->getColumnTypes());
     }
 }

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -36,6 +36,19 @@ use Phinx\Migration\MigrationInterface;
 
 class PostgresAdapter extends PdoAdapter implements AdapterInterface
 {
+    // PostgreSQL support array
+    const PHINX_TYPE_ARRAY_CHAR_PATTERN        = '/^char\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_TEXT_PATTERN        = '/^text\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_INTEGER_PATTERN     = '/^integer\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_FLOAT_PATTERN       = '/^float\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_DECIMAL_PATTERN     = '/^decimal\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_TIMESTAMP_PATTERN   = '/^timestamp\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_TIME_PATTERN        = '/^time\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_DATE_PATTERN        = '/^date\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_BOOLEAN_PATTERN     = '/^boolean\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_JSON_PATTERN        = '/^json\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_UUID_PATTERN        = '/^uuid\[\]{1,}$/';
+
     /**
      * Columns with comments
      *
@@ -729,6 +742,11 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'geography', 'polygon', 4326);
                 break;
             default:
+                if ($this->isArrayType($type))
+                {
+                    return array('name' => $type);
+                }
+                // Return array type
                 throw new \RuntimeException('The type: "' . $type . '" is not supported');
         }
     }
@@ -1076,6 +1094,52 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     public function getColumnTypes()
     {
         return array_merge(parent::getColumnTypes(), array('json', 'uuid'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkColumnType(Column $column)
+    {
+        if (in_array($column->getType(), $this->getColumnTypes()) || $this->isArrayType($column->getType()))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if provided type is valid
+     *
+     * @param $type
+     * @return bool
+     */
+    private function isArrayType($type)
+    {
+        $arrayTypes = array(
+            static::PHINX_TYPE_ARRAY_CHAR_PATTERN,
+            static::PHINX_TYPE_ARRAY_TEXT_PATTERN,
+            static::PHINX_TYPE_ARRAY_INTEGER_PATTERN,
+            static::PHINX_TYPE_ARRAY_FLOAT_PATTERN,
+            static::PHINX_TYPE_ARRAY_DECIMAL_PATTERN,
+            static::PHINX_TYPE_ARRAY_TIMESTAMP_PATTERN,
+            static::PHINX_TYPE_ARRAY_TIME_PATTERN,
+            static::PHINX_TYPE_ARRAY_DATE_PATTERN,
+            static::PHINX_TYPE_ARRAY_BOOLEAN_PATTERN,
+            static::PHINX_TYPE_ARRAY_JSON_PATTERN,
+            static::PHINX_TYPE_ARRAY_UUID_PATTERN,
+        );
+
+        foreach ($arrayTypes as $_arrTypePattern)
+        {
+            if (preg_match($_arrTypePattern, $type))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -37,17 +37,17 @@ use Phinx\Migration\MigrationInterface;
 class PostgresAdapter extends PdoAdapter implements AdapterInterface
 {
     // PostgreSQL support array
-    const PHINX_TYPE_ARRAY_CHAR_PATTERN        = '/^char\[\]{1,}$/';
-    const PHINX_TYPE_ARRAY_TEXT_PATTERN        = '/^text\[\]{1,}$/';
-    const PHINX_TYPE_ARRAY_INTEGER_PATTERN     = '/^integer\[\]{1,}$/';
-    const PHINX_TYPE_ARRAY_FLOAT_PATTERN       = '/^float\[\]{1,}$/';
-    const PHINX_TYPE_ARRAY_DECIMAL_PATTERN     = '/^decimal\[\]{1,}$/';
-    const PHINX_TYPE_ARRAY_TIMESTAMP_PATTERN   = '/^timestamp\[\]{1,}$/';
-    const PHINX_TYPE_ARRAY_TIME_PATTERN        = '/^time\[\]{1,}$/';
-    const PHINX_TYPE_ARRAY_DATE_PATTERN        = '/^date\[\]{1,}$/';
-    const PHINX_TYPE_ARRAY_BOOLEAN_PATTERN     = '/^boolean\[\]{1,}$/';
-    const PHINX_TYPE_ARRAY_JSON_PATTERN        = '/^json\[\]{1,}$/';
-    const PHINX_TYPE_ARRAY_UUID_PATTERN        = '/^uuid\[\]{1,}$/';
+    const PHINX_TYPE_ARRAY_CHAR_PATTERN        = '/^char(\[\]){1,}$/';
+    const PHINX_TYPE_ARRAY_TEXT_PATTERN        = '/^text(\[\]){1,}$/';
+    const PHINX_TYPE_ARRAY_INTEGER_PATTERN     = '/^integer(\[\]){1,}$/';
+    const PHINX_TYPE_ARRAY_FLOAT_PATTERN       = '/^float(\[\]){1,}$/';
+    const PHINX_TYPE_ARRAY_DECIMAL_PATTERN     = '/^decimal(\[\]){1,}$/';
+    const PHINX_TYPE_ARRAY_TIMESTAMP_PATTERN   = '/^timestamp(\[\]){1,}$/';
+    const PHINX_TYPE_ARRAY_TIME_PATTERN        = '/^time(\[\]){1,}$/';
+    const PHINX_TYPE_ARRAY_DATE_PATTERN        = '/^date(\[\]){1,}$/';
+    const PHINX_TYPE_ARRAY_BOOLEAN_PATTERN     = '/^boolean(\[\]){1,}$/';
+    const PHINX_TYPE_ARRAY_JSON_PATTERN        = '/^json(\[\]){1,}$/';
+    const PHINX_TYPE_ARRAY_UUID_PATTERN        = '/^uuid(\[\]){1,}$/';
 
     /**
      * Columns with comments

--- a/src/Phinx/Db/Adapter/ProxyAdapter.php
+++ b/src/Phinx/Db/Adapter/ProxyAdapter.php
@@ -621,4 +621,11 @@ class ProxyAdapter implements AdapterInterface
     public function getConnection() {
         return $this->getAdapter()->getConnection();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkColumnType(Column $column) {
+        return in_array($column->getType(), $this->getColumnTypes());
+    }
 }

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -318,8 +318,8 @@ class Table
             $column = $columnName;
         }
 
-        // check column type
-        if (!in_array($column->getType(), $this->getAdapter()->getColumnTypes())) {
+        // Delegate to Adapters to check column type
+        if (!$this->getAdapter()->checkColumnType($column)) {
             throw new \InvalidArgumentException("An invalid column type was specified: {$column->getName()}");
         }
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -264,6 +264,40 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
             }
         }
     }
+
+    public function providerArrayType()
+    {
+        return array(
+            array('array_text', 'text[]'),
+            array('array_char', 'char[]'),
+            array('array_integer', 'integer[]'),
+            array('array_float', 'float[]'),
+            array('array_decimal', 'decimal[]'),
+            array('array_timestamp', 'timestamp[]'),
+            array('array_time', 'time[]'),
+            array('array_date', 'date[]'),
+            array('array_boolean', 'boolean[]'),
+            array('array_json', 'json[]'),
+            array('array_uuid', 'uuid[]'),
+        );
+    }
+
+    /**
+     *
+     * @dataProvider providerArrayType
+     * @param $column_name
+     * @param $column_type
+     */
+    public function testAddColumnArrayType($column_name, $column_type)
+    {
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->save();
+        $this->assertFalse($table->hasColumn($column_name));
+        $table->addColumn($column_name, $column_type)
+            ->save();
+        $this->assertTrue($table->hasColumn($column_name));
+    }
+    
     public function testRenameColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -278,6 +278,8 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
             array('array_date', 'date[]'),
             array('array_boolean', 'boolean[]'),
             array('array_json', 'json[]'),
+            array('array_json2d', 'json[][]'),
+            array('array_json3d', 'json[][][]'),
             array('array_uuid', 'uuid[]'),
         );
     }


### PR DESCRIPTION
PostgreSql's Array type is there (http://www.postgresql.org/docs/9.3/static/arrays.html) since version **9.0**.
Now we support it in Phinx!