### PR TITLE
auto timestamp migration class names if auto_timestamp_class is set in configuration

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -251,7 +251,21 @@ class Config implements \ArrayAccess
 
         return $path;
     }
-    
+
+    /**
+     * Get the flag tp auto timestamp migration class names
+     * If missing return false for backward compatibility
+     * 
+     * @return boolean
+     */
+    public function getAutoTimestampClass()
+    {
+        if (!isset($this->values['auto_timestamp_class'])) {
+            return false;
+        }
+        return filter_var($this->values['auto_timestamp_class'], FILTER_VALIDATE_BOOLEAN);
+    }
+
     /**
      * Replace tokens in the specified array.
      *

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -74,19 +74,15 @@ class Create extends AbstractCommand
                 $path
             ));
         }
-        
-        $path = realpath($path);
-        $className = $input->getArgument('name');
-        
-        if (!Util::isValidMigrationClassName($className)) {
-            throw new \InvalidArgumentException(sprintf(
-                'The migration class name "%s" is invalid. Please use CamelCase format.',
-                $className
-            ));
-        }
-        
+
+        // Compute the class name and file name
+        $autoTimestampClass = $this->getConfig()->getAutoTimestampClass();
+
+        $className = Util::generateClassName($input->getArgument('name'), $autoTimestampClass);
+        $fileName  = Util::mapClassNameToFileName($className, $autoTimestampClass);
+
         // Compute the file path
-        $fileName = Util::mapClassNameToFileName($className);
+        $path     = realpath($path);
         $filePath = $path . DIRECTORY_SEPARATOR . $fileName;
         
         if (file_exists($filePath)) {

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -375,16 +375,13 @@ class Manager
                     if (isset($versions[$version])) {
                         throw new \InvalidArgumentException(sprintf('Duplicate migration - "%s" has the same version as "%s"', $filePath, $versions[$version]->getVersion()));
                     }
-                    
+
                     // convert the filename to a class name
-                    $class = preg_replace('/^[0-9]+_/', '', basename($filePath));
-                    $class = str_replace('_', ' ', $class);
-                    $class = ucwords($class);
-                    $class = str_replace(' ', '', $class);
-                    if (false !== strpos($class, '.')) {
-                        $class = substr($class, 0, strpos($class, '.'));
-                    }
-                    
+                    $class = Util::mapFileNameToClassName(
+                        basename($filePath),
+                        $this->getConfig()->getAutoTimestampClass()
+                    );
+
                     if (isset($fileNames[$class])) {
                         throw new \InvalidArgumentException(sprintf(
                             'Migration "%s" has the same name as "%s"',

--- a/tests/Phinx/Migration/UtilTest.php
+++ b/tests/Phinx/Migration/UtilTest.php
@@ -31,6 +31,18 @@ class UtilTest extends \PHPUnit_Framework_TestCase
         foreach ($expectedResults as $input => $expectedResult) {
             $this->assertRegExp($expectedResult, Util::mapClassNameToFileName($input));
         }
+
+        // with timestamp
+        $expectedResults = array(
+            'CamelCase87afterSomeBooze_20141231102030'   => '/^\d{14}_camel_case87after_some_booze\.php$/',
+            'CreateUserTable_20141231102030'             => '/^\d{14}_create_user_table\.php$/',
+            'LimitResourceNamesTo30Chars_20141231102030' => '/^\d{14}_limit_resource_names_to30_chars\.php$/',
+        );
+
+        foreach ($expectedResults as $input => $expectedResult) {
+            $this->assertRegExp($expectedResult, Util::mapClassNameToFileName($input, true));
+        }
+
     }
 
     public function testIsValidMigrationClassName()
@@ -46,4 +58,80 @@ class UtilTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($expectedResult, Util::isValidMigrationClassName($input));
         }
     }
+
+    public static function generateClassNameDataProvider()
+    {
+        $timestamp = '\d{14}';
+        return array(
+            array('123', false, false),
+            array('123', true, false),
+            array('abc123', false, '/^Abc123$/'),
+            array('abc123', true, '/^Abc123_' . $timestamp . '$/'),
+            array('abc', false, '/^Abc$/'),
+            array('abc', true, '/^Abc_' . $timestamp . '$/'),
+            array('abcDef', false, '/^AbcDef$/'),
+            array('abcDef', true, '/^AbcDef_' . $timestamp . '$/'),
+        );
+    }
+
+    /**
+     *
+     * @param string  $name           Class name
+     * @param boolean $autoTimestamp  Auto timestamp class names is enabled?
+     * @param boolean $expectedResult String or false if an exception is expected (invalid argument)
+     *
+     * @dataProvider generateClassNameDataProvider
+     */
+    public function testGenerateClassName($name, $autoTimestamp, $expectedResult)
+    {
+        try {
+            $result = Util::generateClassName($name, $autoTimestamp);
+            if ($expectedResult === false) {
+                self::fail('Expected exception but not thrown');
+            }
+            self::assertRegExp($expectedResult, $result);
+        } catch (\InvalidArgumentException $ex) {
+            if ($expectedResult !== false) {
+                self::fail('Unexpected exception: '.$ex->getMessage);
+            }
+        }
+    }
+
+
+    public static function mapFileNameToClassNameDataProvider()
+    {
+        $timestamp = '20141231102030';
+        return array(
+            array($timestamp . '_abc.php', false, '/^Abc$/'),
+            array($timestamp . '_abc.php', true, '/^Abc_\d{14}$/'),
+            array($timestamp . '_abc_def.php', false, '/^AbcDef$/'),
+            array($timestamp . '_abc_def.php', true, '/^AbcDef_\d{14}$/'),
+            array($timestamp . '_abc123_def.php', false, '/^Abc123Def$/'),
+            array($timestamp . '_abc123_def.php', true, '/^Abc123Def_\d{14}$/'),
+        );
+    }
+
+    /**
+     *
+     * @param string  $fileName       File name
+     * @param boolean $autoTimestamp  Auto timestamp class names is enabled?
+     * @param boolean $expectedResult String or false if an exception is expected (invalid argument)
+     *
+     * @dataProvider mapFileNameToClassNameDataProvider
+     */
+    public function testMapFileNameToClassName($fileName, $autoTimestamp, $expectedResult)
+    {
+        try {
+            $result = Util::mapFileNameToClassName($fileName, $autoTimestamp);
+            if ($expectedResult === false) {
+                self::fail('Expected exception but not thrown');
+            }
+            self::assertRegExp($expectedResult, $result);
+        } catch (\InvalidArgumentException $ex) {
+            if ($expectedResult !== false) {
+                self::fail('Unexpected exception: '.$ex->getMessage);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
This is implementation of the issue #306. I'm missing this feature too, it is even a blocker for me.

I've created a new configuration option named "auto_timestamp_class". When this is set to "yes", "true" or 1, the class name will be suffixed by the timestamp, which avoids conflict in names. If the configuration value is missing or "no", "false" or "0" it works as before (thus it is backward compatible)

I've chosen postfix instead of prefix because PHP class names must start with a letter or underscore.

I've also included a small fix to upper case the first letter of the migration name automatically, i.e. it is now equivalent
phinx create Abc
and
phinx create abc

This pull request is replacing #328 