### PR TITLE
Add support for different INT sizes to MysqlAdapter, refs #249

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -65,11 +65,6 @@ interface AdapterInterface
     const PHINX_TYPE_LINESTRING     = 'linestring';
     const PHINX_TYPE_POLYGON        = 'polygon';
 
-    // MySQL specific text types
-    const PHINX_TYPE_TINYTEXT       = 'tinytext';
-    const PHINX_TYPE_MEDIUMTEXT     = 'mediumtext';
-    const PHINX_TYPE_LONGTEXT       = 'longtext';
-
     /**
      * Get all migrated version numbers.
      *

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -379,10 +379,11 @@ interface AdapterInterface
     /**
      * Converts the Phinx logical type to the adapter's SQL type.
      *
-     * @param string $type Type
+     * @param string $type
+     * @param integer $limit
      * @return string
      */
-    public function getSqlType($type);
+    public function getSqlType($type, $limit = null);
 
     /**
      * Creates a new database.

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -48,6 +48,12 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     const TEXT_MEDIUM  = 16777215;
     const TEXT_LONG    = 4294967295;
 
+    const INT_TINY    = 255;
+    const INT_SMALL   = 65535;
+    const INT_MEDIUM  = 16777215;
+    const INT_REGULAR = 4294967295;
+    const INT_BIG     = 18446744073709551615;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -707,7 +707,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getSqlType($type)
+    public function getSqlType($type, $limit = null)
     {
         switch ($type) {
             case static::PHINX_TYPE_STRING:

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -680,7 +680,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getSqlType($type)
+    public function getSqlType($type, $limit = null)
     {
         switch ($type) {
             case static::PHINX_TYPE_INTEGER:

--- a/src/Phinx/Db/Adapter/ProxyAdapter.php
+++ b/src/Phinx/Db/Adapter/ProxyAdapter.php
@@ -422,9 +422,9 @@ class ProxyAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getSqlType($type)
+    public function getSqlType($type, $limit = null)
     {
-        return $this->getAdapter()->getSqlType($type);
+        return $this->getAdapter()->getSqlType($type, $limit);
     }
 
     /**

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -789,7 +789,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getSqlType($type)
+    public function getSqlType($type, $limit = null)
     {
         switch ($type) {
             case static::PHINX_TYPE_STRING:

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -828,7 +828,7 @@ ORDER BY T.[name], I.[index_id];";
     /**
      * {@inheritdoc}
      */
-    public function getSqlType($type)
+    public function getSqlType($type, $limit = null)
     {
         switch ($type) {
             case static::PHINX_TYPE_STRING:

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -452,9 +452,9 @@ class TablePrefixAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getSqlType($type)
+    public function getSqlType($type, $limit = null)
     {
-        return $this->getAdapter()->getSqlType($type);
+        return $this->getAdapter()->getSqlType($type, $limit);
     }
     
     /**

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -481,8 +481,8 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $table->addColumn('column1', 'text', array('limit' => MysqlAdapter::TEXT_LONG))
               ->save();
         $columns = $table->getColumns('t');
-        $this->assertEquals('text', $columns[1]->getType());
-        $this->assertEquals(MysqlAdapter::TEXT_LONG, $columns[1]->getLimit());
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals('longtext', $sqlType['name']);
     }
 
     public function testMediumTextColumn()
@@ -491,8 +491,8 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $table->addColumn('column1', 'text', array('limit' => MysqlAdapter::TEXT_MEDIUM))
               ->save();
         $columns = $table->getColumns('t');
-        $this->assertEquals('text', $columns[1]->getType());
-        $this->assertEquals(MysqlAdapter::TEXT_MEDIUM, $columns[1]->getLimit());
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals('mediumtext', $sqlType['name']);
     }
 
     public function testTinyTextColumn()
@@ -501,8 +501,8 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $table->addColumn('column1', 'text', array('limit' => MysqlAdapter::TEXT_TINY))
               ->save();
         $columns = $table->getColumns('t');
-        $this->assertEquals('text', $columns[1]->getType());
-        $this->assertEquals(MysqlAdapter::TEXT_TINY, $columns[1]->getLimit());
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals('tinytext', $sqlType['name']);
     }
 
     public function testBigIntegerColumn()

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -481,7 +481,8 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $table->addColumn('column1', 'text', array('limit' => MysqlAdapter::TEXT_LONG))
               ->save();
         $columns = $table->getColumns('t');
-        $this->assertEquals('longtext', $columns[1]->getType());
+        $this->assertEquals('text', $columns[1]->getType());
+        $this->assertEquals(MysqlAdapter::TEXT_LONG, $columns[1]->getLimit());
     }
 
     public function testMediumTextColumn()
@@ -490,16 +491,18 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $table->addColumn('column1', 'text', array('limit' => MysqlAdapter::TEXT_MEDIUM))
               ->save();
         $columns = $table->getColumns('t');
-        $this->assertEquals('mediumtext', $columns[1]->getType());
+        $this->assertEquals('text', $columns[1]->getType());
+        $this->assertEquals(MysqlAdapter::TEXT_MEDIUM, $columns[1]->getLimit());
     }
 
     public function testTinyTextColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
-        $table->addColumn('column1', 'text', array('limit' => MysqlAdapter::TEXT_SMALL))
+        $table->addColumn('column1', 'text', array('limit' => MysqlAdapter::TEXT_TINY))
               ->save();
         $columns = $table->getColumns('t');
-        $this->assertEquals('tinytext', $columns[1]->getType());
+        $this->assertEquals('text', $columns[1]->getType());
+        $this->assertEquals(MysqlAdapter::TEXT_TINY, $columns[1]->getLimit());
     }
 
     public function testDropColumn()

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -505,6 +505,46 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(MysqlAdapter::TEXT_TINY, $columns[1]->getLimit());
     }
 
+    public function testBigIntegerColumn()
+    {
+        $table = new \Phinx\Db\Table('t', array(), $this->adapter);
+        $table->addColumn('column1', 'integer', array('limit' => MysqlAdapter::INT_BIG))
+              ->save();
+        $columns = $table->getColumns('t');
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals('bigint', $sqlType['name']);
+    }
+
+    public function testMediumIntegerColumn()
+    {
+        $table = new \Phinx\Db\Table('t', array(), $this->adapter);
+        $table->addColumn('column1', 'integer', array('limit' => MysqlAdapter::INT_MEDIUM))
+              ->save();
+        $columns = $table->getColumns('t');
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals('mediumint', $sqlType['name']);
+    }
+
+    public function testSmallIntegerColumn()
+    {
+        $table = new \Phinx\Db\Table('t', array(), $this->adapter);
+        $table->addColumn('column1', 'integer', array('limit' => MysqlAdapter::INT_SMALL))
+              ->save();
+        $columns = $table->getColumns('t');
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals('smallint', $sqlType['name']);
+    }
+
+    public function testTinyIntegerColumn()
+    {
+        $table = new \Phinx\Db\Table('t', array(), $this->adapter);
+        $table->addColumn('column1', 'integer', array('limit' => MysqlAdapter::INT_TINY))
+              ->save();
+        $columns = $table->getColumns('t');
+        $sqlType = $this->adapter->getSqlType($columns[1]->getType(), $columns[1]->getLimit());
+        $this->assertEquals('tinyint', $sqlType['name']);
+    }
+
     public function testDropColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);


### PR DESCRIPTION
- add `$limit` parameter to `AdapterInterface::getSqlType`, allowing more complex type hinting
- additional column sizes for "text" and "integer" types now determined by `MysqlAdapter::getSqlType`
- `$limit` is passed through `getSqlType`

Cleans up a some of the changes made in #330:

- remove `PHINX_TYPE_*` constants from `AdapterInterface`
- deprecate `TEXT_SMALL` in favor of `TEXT_TINY` in `MysqlAdapter`
- remove the `classifyTextColumn` method in `MysqlAdapter`