### PR TITLE
Create WrapperInterface and AdapterWrapper, refs #413

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -81,11 +81,27 @@ interface AdapterInterface
     public function setOptions(array $options);
 
     /**
-     * Get adapter options.
+     * Get all adapter options.
      *
      * @return array
      */
     public function getOptions();
+
+    /**
+     * Check if an option has been set.
+     *
+     * @param  string $name
+     * @return boolean
+     */
+    public function hasOption($name);
+
+    /**
+     * Get a single adapter option, or null if the option does not exist.
+     *
+     * @param  string $name
+     * @return mixed
+     */
+    public function getOption($name);
 
     /**
      * Sets the console output.

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -73,6 +73,21 @@ interface AdapterInterface
     public function getVersions();
 
     /**
+     * Set adapter configuration options.
+     *
+     * @param  array $options
+     * @return AdapterInterface
+     */
+    public function setOptions(array $options);
+
+    /**
+     * Get adapter options.
+     *
+     * @return array
+     */
+    public function getOptions();
+
+    /**
      * Sets the console output.
      *
      * @param OutputInterface $output Output

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -95,6 +95,22 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * {@inheritdoc}
      */
+    public function hasOption($name)
+    {
+        return $this->adapter->hasOption($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOption($name)
+    {
+        return $this->adapter->getOption($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setOutput(OutputInterface $output)
     {
         $this->adapter->setOutput($output);

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -1,0 +1,416 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Db\Adapter
+ */
+namespace Phinx\Db\Adapter;
+
+use Phinx\Db\Table;
+use Phinx\Db\Table\Column;
+use Phinx\Db\Table\Index;
+use Phinx\Db\Table\ForeignKey;
+use Phinx\Migration\MigrationInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Adapter Wrapper.
+ *
+ * Proxy commands through to another adapter, allowing modification of
+ * parameters during calls.
+ *
+ * @author Woody Gilk <woody.gilk@gmail.com>
+ */
+abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
+{
+    /**
+     * @var AdapterInterface
+     */
+    protected $adapter;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(AdapterInterface $adapter)
+    {
+        $this->setAdapter($adapter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAdapter(AdapterInterface $adapter)
+    {
+        $this->adapter = $adapter;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(array $options)
+    {
+        $this->adapter->setOptions($options);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOptions()
+    {
+        return $this->adapter->getOptions();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOutput(OutputInterface $output)
+    {
+        $this->adapter->setOutput($output);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOutput()
+    {
+        return $this->adapter->getOutput($output);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function connect()
+    {
+        return $this->getAdapter()->connect();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disconnect()
+    {
+        return $this->getAdapter()->disconnect();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($sql)
+    {
+        return $this->getAdapter()->execute($sql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function query($sql)
+    {
+        return $this->getAdapter()->query($sql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchRow($sql)
+    {
+        return $this->getAdapter()->fetchRow($sql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAll($sql)
+    {
+        return $this->getAdapter()->fetchAll($sql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersions()
+    {
+        return $this->getAdapter()->getVersions();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)
+    {
+        $this->getAdapter()->migrated($migration, $direction, $startTime, $endTime);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSchemaTable()
+    {
+        return $this->getAdapter()->hasSchemaTable();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createSchemaTable()
+    {
+        return $this->getAdapter()->createSchemaTable();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnTypes()
+    {
+        return $this->getAdapter()->getColumnTypes();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasTransactions()
+    {
+        return $this->getAdapter()->hasTransaction();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function beginTransaction()
+    {
+        return $this->getAdapter()->beginTransaction();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commitTransaction()
+    {
+        return $this->getAdapter()->commitTransaction();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rollbackTransaction()
+    {
+        return $this->getAdapter()->rollbackTransaction();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function quoteTableName($tableName)
+    {
+        return $this->getAdapter()->quoteTableName($tableName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function quoteColumnName($columnName)
+    {
+        return $this->getAdapter()->quoteColumnName($columnName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasTable($tableName)
+    {
+        return $this->getAdapter()->hasTable($tableName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createTable(Table $table)
+    {
+        return $this->getAdapter()->createTable($table);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renameTable($tableName, $newTableName)
+    {
+        return $this->getAdapter()->renameTable($tableName, $newTableName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dropTable($tableName)
+    {
+        return $this->getAdapter()->dropTable($tableName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumns($tableName)
+    {
+        return $this->getAdapter()->getColumns($tableName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasColumn($tableName, $columnName)
+    {
+        return $this->getAdapter()->hasColumn($tableName, $columnName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addColumn(Table $table, Column $column)
+    {
+        return $this->getAdapter()->addColumn($table, $column);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renameColumn($tableName, $columnName, $newColumnName)
+    {
+        return $this->getAdapter()->renameColumn($tableName, $columnName, $newColumnName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function changeColumn($tableName, $columnName, Column $newColumn)
+    {
+        return $this->getAdapter()->changeColumn($tableName, $columnName, $newColumn);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dropColumn($tableName, $columnName)
+    {
+        return $this->getAdapter()->dropColumn($tableName, $columnName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasIndex($tableName, $columns)
+    {
+        return $this->getAdapter()->hasIndex($tableName, $columns);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addIndex(Table $table, Index $index)
+    {
+        return $this->getAdapter()->addIndex($table, $index);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dropIndex($tableName, $columns, $options = array())
+    {
+        return $this->getAdapter()->dropIndex($tableName, $columns, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dropIndexByName($tableName, $indexName)
+    {
+        return $this->getAdapter()->dropIndexByName($tableName, $indexName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasForeignKey($tableName, $columns, $constraint = null)
+    {
+        return $this->getAdapter()->hasForeignKey($tableName, $columns, $constraint);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addForeignKey(Table $table, ForeignKey $foreignKey)
+    {
+        return $this->getAdapter()->addForeignKey($table, $foreignKey);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dropForeignKey($tableName, $columns, $constraint = null)
+    {
+        return $this->getAdapter()->dropForeignKey($tableName, $columns, $constraint);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSqlType($type)
+    {
+        return $this->getAdapter()->getSqlType($type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createDatabase($name, $options = array())
+    {
+        return $this->getAdapter()->createDatabase($name, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasDatabase($name)
+    {
+        return $this->getAdapter()->hasDatabase($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dropDatabase($name)
+    {
+        return $this->getAdapter()->dropDatabase($name);
+    }
+}

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -401,9 +401,9 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * {@inheritdoc}
      */
-    public function getSqlType($type)
+    public function getSqlType($type, $limit = null)
     {
-        return $this->getAdapter()->getSqlType($type);
+        return $this->getAdapter()->getSqlType($type, $limit);
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -43,7 +43,7 @@ abstract class PdoAdapter implements AdapterInterface
     /**
      * @var array
      */
-    protected $options;
+    protected $options = array();
 
     /**
      * @var OutputInterface
@@ -80,10 +80,7 @@ abstract class PdoAdapter implements AdapterInterface
     }
 
     /**
-     * Sets the adapter options.
-     *
-     * @param array $options Options
-     * @return AdapterInterface
+     * {@inheritdoc}
      */
     public function setOptions(array $options)
     {
@@ -101,13 +98,30 @@ abstract class PdoAdapter implements AdapterInterface
     }
 
     /**
-     * Gets the adapter options.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getOptions()
     {
         return $this->options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasOption($name)
+    {
+        return isset($this->options[$name]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOption($name)
+    {
+        if (!$this->hasOption($name)) {
+            return null;
+        }
+        return $this->options[$name];
     }
 
     /**
@@ -395,8 +409,7 @@ abstract class PdoAdapter implements AdapterInterface
      */
     public function getAdapterType()
     {
-        $options = $this->getOptions();
-        return $options['adapter'];
+        return $this->getOption('adapter');
     }
 
     /**

--- a/src/Phinx/Db/Adapter/ProxyAdapter.php
+++ b/src/Phinx/Db/Adapter/ProxyAdapter.php
@@ -28,12 +28,10 @@
  */
 namespace Phinx\Db\Adapter;
 
-use Symfony\Component\Console\Output\OutputInterface;
 use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Index;
 use Phinx\Db\Table\ForeignKey;
-use Phinx\Migration\MigrationInterface;
 use Phinx\Migration\IrreversibleMigrationException;
 
 /**
@@ -43,176 +41,12 @@ use Phinx\Migration\IrreversibleMigrationException;
  *
  * @author Rob Morgan <robbym@gmail.com>
  */
-class ProxyAdapter implements AdapterInterface
+class ProxyAdapter extends AdapterWrapper
 {
-    /**
-     * @var AdapterInterface
-     */
-    protected $adapter;
-
     /**
      * @var array
      */
     protected $commands;
-
-    /**
-     * Class Constructor.
-     *
-     * @param AdapterInterface $adapter The adapter to proxy commands to
-     * @param OutputInterface  $output  Output Interface
-     * @return void
-     */
-    public function __construct(AdapterInterface $adapter = null, OutputInterface $output = null)
-    {
-        if (null !== $adapter) {
-            $this->setAdapter($adapter);
-        }
-        if (null !== $output) {
-            $this->setOutput($output);
-        }
-    }
-
-    /**
-     * Sets the database adapter to proxy commands to.
-     *
-     * @param AdapterInterface $adapter Database Adapter
-     * @return AdapterInterface
-     */
-    public function setAdapter(AdapterInterface $adapter)
-    {
-        $this->adapter = $adapter;
-        return $this;
-    }
-
-    /**
-     * Gets the database adapter.
-     *
-     * @return AdapterInterface
-     */
-    public function getAdapter()
-    {
-        return $this->adapter;
-    }
-
-    /**
-     * Sets the adapter options.
-     *
-     * @param array $options Options
-     * @return AdapterInterface
-     */
-    public function setOptions(array $options)
-    {
-        $this->options = $options;
-        return $this;
-    }
-
-    /**
-     * Gets the adapter options.
-     *
-     * @return array
-     */
-    public function getOptions()
-    {
-        return $this->options;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setOutput(OutputInterface $output)
-    {
-        $this->adapter->setOutput($output);
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getOutput()
-    {
-        return $this->adapter->getOutput($output);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function connect()
-    {
-        $this->getAdapter()->connect();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function disconnect()
-    {
-        $this->getAdapter()->disconnect();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function execute($sql)
-    {
-        return $this->getAdapter()->execute($sql);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function query($sql)
-    {
-        return $this->getAdapter()->query($sql);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function fetchRow($sql)
-    {
-        return $this->getAdapter()->fetchRow($sql);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function fetchAll($sql)
-    {
-        return $this->getAdapter()->fetchAll($sql);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getVersions()
-    {
-        return $this->getAdapter()->getVersions();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)
-    {
-        $this->getAdapter()->migrated($migration, $direction, $startTime, $endTime);
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasSchemaTable()
-    {
-        return $this->getAdapter()->hasSchemaTable();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createSchemaTable()
-    {
-        return $this->getAdapter()->createSchemaTable();
-    }
 
     /**
      * {@inheritdoc}
@@ -221,71 +55,6 @@ class ProxyAdapter implements AdapterInterface
     {
         return 'ProxyAdapter';
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getColumnTypes()
-    {
-        return $this->getAdapter()->getColumnTypes();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasTransactions()
-    {
-        return $this->getAdapter()->hasTransaction();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function beginTransaction()
-    {
-        return $this->getAdapter()->beginTransaction();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function commitTransaction()
-    {
-        return $this->getAdapter()->commitTransaction();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function rollbackTransaction()
-    {
-        return $this->getAdapter()->rollbackTransaction();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function quoteTableName($tableName)
-    {
-        return $this->getAdapter()->quoteTableName($tableName);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function quoteColumnName($columnName)
-    {
-        return $this->getAdapter()->quoteColumnName($columnName);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasTable($tableName)
-    {
-        return $this->getAdapter()->hasTable($tableName);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -308,22 +77,6 @@ class ProxyAdapter implements AdapterInterface
     public function dropTable($tableName)
     {
         $this->recordCommand('dropTable', array($tableName));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getColumns($tableName)
-    {
-        return $this->getAdapter()->getColumns($tableName);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasColumn($tableName, $columnName)
-    {
-        return $this->getAdapter()->hasColumn($tableName, $columnName);
     }
 
     /**
@@ -361,14 +114,6 @@ class ProxyAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function hasIndex($tableName, $columns)
-    {
-        return $this->getAdapter()->hasIndex($tableName, $columns);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function addIndex(Table $table, Index $index)
     {
         $this->recordCommand('addIndex', array($table, $index));
@@ -393,14 +138,6 @@ class ProxyAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function hasForeignKey($tableName, $columns, $constraint = null)
-    {
-        return $this->getAdapter()->hasForeignKey($tableName, $columns, $constraint);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function addForeignKey(Table $table, ForeignKey $foreignKey)
     {
         $this->recordCommand('addForeignKey', array($table, $foreignKey));
@@ -417,33 +154,9 @@ class ProxyAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getSqlType($type, $limit = null)
-    {
-        return $this->getAdapter()->getSqlType($type, $limit);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function createDatabase($name, $options = array())
     {
         $this->recordCommand('createDatabase', array($name, $options));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasDatabase($name)
-    {
-        return $this->getAdapter()->hasDatabase($name);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function dropDatabase($name)
-    {
-        return $this->getAdapter()->dropDatabase($name);
     }
 
     /**
@@ -608,12 +321,5 @@ class ProxyAdapter implements AdapterInterface
     public function invertAddForeignKey($args)
     {
         return array('name' => 'dropForeignKey', 'arguments' => array($args[0]->getName(), $args[1]->getColumns()));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getConnection() {
-        return $this->getAdapter()->getConnection();
     }
 }

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -28,7 +28,6 @@
  */
 namespace Phinx\Db\Adapter;
 
-use Symfony\Component\Console\Output\OutputInterface;
 use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Index;
@@ -42,237 +41,14 @@ use Phinx\Migration\MigrationInterface;
  *
  * @author Samuel Fisher <sam@sfisher.co>
  */
-class TablePrefixAdapter implements AdapterInterface
+class TablePrefixAdapter extends AdapterWrapper
 {
-    /**
-     * @var AdapterInterface
-     */
-    protected $adapter;
-
-    /**
-     * @var array
-     */
-    protected $options;
-
-    /**
-     * Class Constructor.
-     *
-     * @param array $options Options
-     * @param AdapterInterface $adapter The adapter to proxy commands to
-     * @return void
-     */
-    public function __construct(array $options, AdapterInterface $adapter = null)
-    {
-        $this->setOptions($options);
-        if (null !== $adapter) {
-            $this->setAdapter($adapter);
-        }
-    }
-
-    /**
-     * Sets the database adapter to proxy commands to.
-     *
-     * @param AdapterInterface $adapter Database Adapter
-     * @return AdapterInterface
-     */
-    public function setAdapter(AdapterInterface $adapter)
-    {
-        $this->adapter = $adapter;
-        return $this;
-    }
-
-    /**
-     * Gets the database adapter.
-     *
-     * @return AdapterInterface
-     */
-    public function getAdapter()
-    {
-        return $this->adapter;
-    }
-
-    /**
-     * Sets the adapter options.
-     *
-     * @param array $options Options
-     * @return AdapterInterface
-     */
-    public function setOptions(array $options)
-    {
-        $this->options = $options;
-        return $this;
-    }
-
-    /**
-     * Gets the adapter options.
-     *
-     * @return array
-     */
-    public function getOptions()
-    {
-        return $this->options;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setOutput(OutputInterface $output)
-    {
-        $this->adapter->setOutput($output);
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getOutput()
-    {
-        return $this->adapter->getOutput();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function connect()
-    {
-        $this->getAdapter()->connect();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function disconnect()
-    {
-        $this->getAdapter()->disconnect();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function execute($sql)
-    {
-        return $this->getAdapter()->execute($sql);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function query($sql)
-    {
-        return $this->getAdapter()->query($sql);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function fetchRow($sql)
-    {
-        return $this->getAdapter()->fetchRow($sql);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function fetchAll($sql)
-    {
-        return $this->getAdapter()->fetchAll($sql);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getVersions()
-    {
-        return $this->getAdapter()->getVersions();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)
-    {
-        $this->getAdapter()->migrated($migration, $direction, $startTime, $endTime);
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasSchemaTable()
-    {
-        return $this->getAdapter()->hasSchemaTable();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createSchemaTable()
-    {
-        return $this->getAdapter()->createSchemaTable();
-    }
-
     /**
      * {@inheritdoc}
      */
     public function getAdapterType()
     {
-        return 'ProxyAdapter';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getColumnTypes()
-    {
-        return $this->getAdapter()->getColumnTypes();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasTransactions()
-    {
-        return $this->getAdapter()->hasTransactions();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function beginTransaction()
-    {
-        return $this->getAdapter()->beginTransaction();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function commitTransaction()
-    {
-        return $this->getAdapter()->commitTransaction();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function rollbackTransaction()
-    {
-        return $this->getAdapter()->rollbackTransaction();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function quoteTableName($tableName)
-    {
-        return $this->getAdapter()->quoteTableName($tableName);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function quoteColumnName($columnName)
-    {
-        return $this->getAdapter()->quoteColumnName($columnName);
+        return 'TablePrefixAdapter';
     }
 
     /**
@@ -281,7 +57,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function hasTable($tableName)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        return $this->getAdapter()->hasTable($adapterTableName);
+        return parent::hasTable($adapterTableName);
     }
 
     /**
@@ -299,7 +75,7 @@ class TablePrefixAdapter implements AdapterInterface
             $adapterReferenceTable->setName($adapterReferenceTableName);
         }
 
-        $this->getAdapter()->createTable($adapterTable);
+        return parent::createTable($adapterTable);
     }
 
     /**
@@ -309,7 +85,7 @@ class TablePrefixAdapter implements AdapterInterface
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
         $adapterNewTableName = $this->getAdapterTableName($newTableName);
-        $this->getAdapter()->renameTable($adapterTableName, $adapterNewTableName);
+        return parent::renameTable($adapterTableName, $adapterNewTableName);
     }
 
     /**
@@ -318,7 +94,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function dropTable($tableName)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        $this->getAdapter()->dropTable($adapterTableName);
+        return parent::dropTable($adapterTableName);
     }
 
     /**
@@ -327,7 +103,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function getColumns($tableName)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        return $this->getAdapter()->getColumns($adapterTableName);
+        return parent::getColumns($adapterTableName);
     }
 
     /**
@@ -336,7 +112,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function hasColumn($tableName, $columnName)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        return $this->getAdapter()->hasColumn($adapterTableName, $columnName);
+        return parent::hasColumn($adapterTableName, $columnName);
     }
 
     /**
@@ -347,7 +123,7 @@ class TablePrefixAdapter implements AdapterInterface
         $adapterTable = clone $table;
         $adapterTableName = $this->getAdapterTableName($table->getName());
         $adapterTable->setName($adapterTableName);
-        $this->getAdapter()->addColumn($adapterTable, $column);
+        return parent::addColumn($adapterTable, $column);
     }
 
     /**
@@ -356,7 +132,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function renameColumn($tableName, $columnName, $newColumnName)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        $this->getAdapter()->renameColumn($adapterTableName, $columnName, $newColumnName);
+        return parent::renameColumn($adapterTableName, $columnName, $newColumnName);
     }
 
     /**
@@ -365,7 +141,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function changeColumn($tableName, $columnName, Column $newColumn)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        $this->getAdapter()->changeColumn($adapterTableName, $columnName, $newColumn);
+        return parent::changeColumn($adapterTableName, $columnName, $newColumn);
     }
 
     /**
@@ -374,7 +150,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function dropColumn($tableName, $columnName)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        $this->getAdapter()->dropColumn($adapterTableName, $columnName);
+        return parent::dropColumn($adapterTableName, $columnName);
     }
 
     /**
@@ -383,7 +159,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function hasIndex($tableName, $columns)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        return $this->getAdapter()->hasIndex($adapterTableName, $columns);
+        return parent::hasIndex($adapterTableName, $columns);
     }
 
     /**
@@ -394,7 +170,7 @@ class TablePrefixAdapter implements AdapterInterface
         $adapterTable = clone $table;
         $adapterTableName = $this->getAdapterTableName($table->getName());
         $adapterTable->setName($adapterTableName);
-        $this->getAdapter()->addIndex($adapterTable, $index);
+        return parent::addIndex($adapterTable, $index);
     }
 
     /**
@@ -403,7 +179,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function dropIndex($tableName, $columns, $options = array())
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        $this->getAdapter()->dropIndex($adapterTableName, $columns, $options);
+        return parent::dropIndex($adapterTableName, $columns, $options);
     }
 
     /**
@@ -412,7 +188,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function dropIndexByName($tableName, $indexName)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        $this->getAdapter()->dropIndexByName($adapterTableName, $indexName);
+        return parent::dropIndexByName($adapterTableName, $indexName);
     }
 
     /**
@@ -421,7 +197,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function hasForeignKey($tableName, $columns, $constraint = null)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        return $this->getAdapter()->hasForeignKey($adapterTableName, $columns, $constraint);
+        return parent::hasForeignKey($adapterTableName, $columns, $constraint);
     }
 
     /**
@@ -432,7 +208,7 @@ class TablePrefixAdapter implements AdapterInterface
         $adapterTable = clone $table;
         $adapterTableName = $this->getAdapterTableName($table->getName());
         $adapterTable->setName($adapterTableName);
-        $this->getAdapter()->addForeignKey($adapterTable, $foreignKey);
+        return parent::addForeignKey($adapterTable, $foreignKey);
     }
 
     /**
@@ -441,47 +217,7 @@ class TablePrefixAdapter implements AdapterInterface
     public function dropForeignKey($tableName, $columns, $constraint = null)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        $this->getAdapter()->dropForeignKey($adapterTableName, $columns, $constraint);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSqlType($type, $limit = null)
-    {
-        return $this->getAdapter()->getSqlType($type, $limit);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function createDatabase($name, $options = array())
-    {
-        $this->getAdapter()->createDatabase($name, $options);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasDatabase($name)
-    {
-        return $this->getAdapter()->hasDatabase($name);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function dropDatabase($name)
-    {
-        return $this->getAdapter()->dropDatabase($name);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getConnection()
-    {
-        return $this->getAdapter()->getConnection();
+        return parent::dropForeignKey($adapterTableName, $columns, $constraint);
     }
 
     /**
@@ -491,19 +227,8 @@ class TablePrefixAdapter implements AdapterInterface
      */
     public function getPrefix()
     {
-        return isset($this->options['table_prefix'])
-            ? $this->options['table_prefix']
-            : '';
-    }
-
-    /**
-     * Sets the table prefix.
-     *
-     * @param string $prefix
-     */
-    public function setPrefix($prefix)
-    {
-        $this->options['table_prefix'] = $prefix;
+        $options = $this->getOptions();
+        return isset($options['table_prefix']) ? $options['table_prefix'] : '';
     }
 
     /**
@@ -513,19 +238,8 @@ class TablePrefixAdapter implements AdapterInterface
      */
     public function getSuffix()
     {
-        return isset($this->options['table_suffix'])
-            ? $this->options['table_suffix']
-            : '';
-    }
-
-    /**
-     * Sets the table suffix.
-     *
-     * @param string $suffix
-     */
-    public function setSuffix($suffix)
-    {
-        $this->options['table_suffix'] = $suffix;
+        $options = $this->getOptions();
+        return isset($options['table_suffix']) ? $options['table_suffix'] : '';
     }
 
     /**

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -227,8 +227,7 @@ class TablePrefixAdapter extends AdapterWrapper
      */
     public function getPrefix()
     {
-        $options = $this->getOptions();
-        return isset($options['table_prefix']) ? $options['table_prefix'] : '';
+        return (string) $this->getOption('table_prefix');
     }
 
     /**
@@ -238,8 +237,7 @@ class TablePrefixAdapter extends AdapterWrapper
      */
     public function getSuffix()
     {
-        $options = $this->getOptions();
-        return isset($options['table_suffix']) ? $options['table_suffix'] : '';
+        return (string) $this->getOption('table_suffix');
     }
 
     /**

--- a/src/Phinx/Db/Adapter/WrapperInterface.php
+++ b/src/Phinx/Db/Adapter/WrapperInterface.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Db\Adapter
+ */
+namespace Phinx\Db\Adapter;
+
+/**
+ * Wrapper Interface.
+ *
+ * @author Woody Gilk <woody.gilk@gmail.com>
+ */
+interface WrapperInterface
+{
+    /**
+     * Class constructor, must always wrap another adapter.
+     *
+     * @param  AdapterInterface $adapter
+     */
+    public function __construct(AdapterInterface $adapter);
+
+    /**
+     * Sets the database adapter to proxy commands to.
+     *
+     * @param  AdapterInterface $adapter
+     * @return AdapterInterface
+     */
+    public function setAdapter(AdapterInterface $adapter);
+
+    /**
+     * Gets the database adapter.
+     *
+     * @throws \RuntimeException if the adapter has not been set
+     * @return AdapterInterface
+     */
+    public function getAdapter();
+}

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -308,7 +308,7 @@ class Environment
         }
         
         // Use the TablePrefixAdapter if table prefix/suffixes are in use
-        if (isset($this->options['table_prefix']) || isset($this->options['table_suffix'])) {
+        if ($adapter->hasOption('table_prefix') || $adapter->hasOption('table_suffix')) {
             $adapter = new TablePrefixAdapter($adapter);
         }
         

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -132,7 +132,7 @@ class Environment
             if ($direction == MigrationInterface::DOWN) {
                 // Create an instance of the ProxyAdapter so we can record all
                 // of the migration commands for reverse playback
-                $proxyAdapter = new ProxyAdapter($this->getAdapter(), $this->getOutput());
+                $proxyAdapter = new ProxyAdapter($this->getAdapter());
                 $migration->setAdapter($proxyAdapter);
                 /** @noinspection PhpUndefinedMethodInspection */
                 $migration->change();
@@ -309,7 +309,7 @@ class Environment
         
         // Use the TablePrefixAdapter if table prefix/suffixes are in use
         if (isset($this->options['table_prefix']) || isset($this->options['table_suffix'])) {
-            $adapter = new TablePrefixAdapter($this->options, $adapter);
+            $adapter = new TablePrefixAdapter($adapter);
         }
         
         return $this->adapter = $adapter;

--- a/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
@@ -18,10 +18,9 @@ class ProxyAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->adapter = new ProxyAdapter();
-
         $stub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $this->adapter->setAdapter($stub);
+
+        $this->adapter = new ProxyAdapter($stub);
     }
 
     public function tearDown()

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -21,14 +21,17 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->adapter = new TablePrefixAdapter(array(
-            'table_prefix' => 'pre_',
-            'table_suffix' => '_suf'
-            ));
-
         $this->mock = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
 
-        $this->adapter->setAdapter($this->mock);
+        $this->mock
+            ->expects($this->any())
+            ->method('getOptions')
+            ->will($this->returnValue(array(
+                'table_prefix' => 'pre_',
+                'table_suffix' => '_suf'
+            )));
+
+        $this->adapter = new TablePrefixAdapter($this->mock);
     }
 
     public function tearDown()

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -21,15 +21,23 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        $options = array(
+            'table_prefix' => 'pre_',
+            'table_suffix' => '_suf',
+        );
+
         $this->mock = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
 
         $this->mock
             ->expects($this->any())
-            ->method('getOptions')
-            ->will($this->returnValue(array(
-                'table_prefix' => 'pre_',
-                'table_suffix' => '_suf'
-            )));
+            ->method('getOption')
+            ->with($this->logicalOr(
+                $this->equalTo('table_prefix'),
+                $this->equalTo('table_suffix')
+            ))
+            ->will($this->returnCallback(function ($option) use ($options) {
+                return $options[$option];
+            }));
 
         $this->adapter = new TablePrefixAdapter($this->mock);
     }


### PR DESCRIPTION
By creating an abstract wrapper class, we can reduce amount of duplication
between ProxyAdapter and TablePrefixAdapter, while providing a more consistent
interface for future development of additional wrappers.

- Add missing setOptions/getOptions to AdapterInterface
- use AdapterWrapper for TablePrefixAdapter
- use AdapterWrapper for ProxyAdapter
- update ProxyAdapter and TablePrefixAdapter usage in Environment