### PR TITLE
Create AdapterFactory to register and load adapters, refs #413, fixes #388

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -154,13 +154,15 @@ Declaring an SQLite database uses a simplified structure:
             adapter: sqlite
             memory: true     # Setting memory to *any* value overrides name
 
-You can provide a custom adapter by registering an implementation of the `Phinx\\Db\\Adapter\\AdapterInterface` with the Environment:
+You can provide a custom adapter by registering an implementation of the `Phinx\\Db\\Adapter\\AdapterInterface`
+with `AdapterFactory`: 
 
 .. code-block:: php
 
-    $customAdapterFactory = function(Phinx\Migration\Manager\Environment $env) {
-        // Configure my adapter with the env and return.
-        $adapter = new \My\Adapter(...);
-        return $adapter;
-    }
-    $environment->registerAdapter('my-adapter', $customAdapterFactory);
+    $name  = 'fizz';
+    $class = 'Acme\Adapter\FizzAdapter';
+
+    AdapterFactory::instance()->registerAdapter($name, $class);
+
+Adapters can be registered any time before `$app->run()` is called, which normally
+called by `bin/phinx`.

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Migration
+ */
+namespace Phinx\Db\Adapter;
+
+use Phinx\Db\Adapter\AdapterInterface;
+
+/**
+ * Adapter factory and registry.
+ *
+ * Used for registering adapters and creating instances of adapters.
+ *
+ * @author Woody Gilk <woody.gilk@gmail.com>
+ */
+class AdapterFactory
+{
+    /**
+     * @var AdapterFactory
+     */
+    protected static $instance;
+
+    /**
+     * Get the factory singleton instance.
+     *
+     * @return AdapterFactory
+     */
+    public static function instance()
+    {
+        if (!static::$instance) {
+            static::$instance = new static();
+        }
+        return static::$instance;
+    }
+
+    /**
+     * Class map of database adapters, indexed by PDO::ATTR_DRIVER_NAME.
+     *
+     * @var array
+     */
+    protected $adapters = array(
+        'mysql'  => 'Phinx\Db\Adapter\MysqlAdapter',
+        'pgsql'  => 'Phinx\Db\Adapter\PostgresAdapter',
+        'sqlite' => 'Phinx\Db\Adapter\SQLiteAdapter',
+        'sqlsrv' => 'Phinx\Db\Adapter\SqlServerAdapter',
+    );
+
+    /**
+     * Class map of adapters wrappers, indexed by name.
+     *
+     * @var array
+     */
+    protected $wrappers = array(
+        'prefix' => 'Phinx\Db\Adapter\TablePrefixAdapter',
+        'proxy'  => 'Phinx\Db\Adapter\ProxyAdapter',
+    );
+
+    /**
+     * Add or replace an adapter with a fully qualified class name.
+     *
+     * @throws \RuntimeException
+     * @param  string $name
+     * @param  string $class
+     * @return $this
+     */
+    public function registerAdapter($name, $class)
+    {
+        if (!is_subclass_of($class, 'Phinx\Db\Adapter\AdapterInterface')) {
+            throw new \RuntimeException(sprintf(
+                'Adapter class "%s" must be implement Phinx\\Db\\Adapter\\AdapterInterface',
+                $class
+            ));
+        }
+        $this->adapters[$name] = $class;
+        return $this;
+    }
+
+    /**
+     * Get an adapter class by name.
+     *
+     * @throws \RuntimeException
+     * @param  string $name
+     * @return string
+     */
+    protected function getClass($name)
+    {
+        if (empty($this->adapters[$name])) {
+            throw new \RuntimeException(sprintf(
+                'Adapter "%s" has not been registered',
+                $name
+            ));
+        }
+        return $this->adapters[$name];
+    }
+
+    /**
+     * Get an adapter instance by name.
+     *
+     * @param  string $name
+     * @param  array  $options
+     * @return AdapterInterface
+     */
+    public function getAdapter($name, array $options)
+    {
+        $class = $this->getClass($name);
+        return new $class($options);
+    }
+
+    /**
+     * Add or replace a wrapper with a fully qualified class name.
+     *
+     * @throws \RuntimeException
+     * @param  string $name
+     * @param  string $class
+     * @return $this
+     */
+    public function registerWrapper($name, $class)
+    {
+        if (!is_subclass_of($class, 'Phinx\Db\Adapter\WrapperInterface')) {
+            throw new \RuntimeException(sprintf(
+                'Wrapper class "%s" must be implement Phinx\\Db\\Adapter\\WrapperInterface',
+                $class
+            ));
+        }
+        $this->wrappers[$name] = $class;
+        return $this;
+    }
+
+    /**
+     * Get a wrapper class by name.
+     *
+     * @throws \RuntimeException
+     * @param  string $name
+     * @return string
+     */
+    protected function getWrapperClass($name)
+    {
+        if (empty($this->wrappers[$name])) {
+            throw new \RuntimeException(sprintf(
+                'Wrapper "%s" has not been registered',
+                $name
+            ));
+        }
+        return $this->wrappers[$name];
+    }
+
+    /**
+     * Get a wrapper instance by name.
+     *
+     * @param  string $name
+     * @param  AdapterInterface $adapter
+     * @return AdapterInterface
+     */
+    public function getWrapper($name, AdapterInterface $adapter)
+    {
+        $class = $this->getWrapperClass($name);
+        return new $class($adapter);
+    }
+}

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -28,15 +28,10 @@
  */
 namespace Phinx\Migration\Manager;
 
-use Phinx\Db\Adapter\SqlServerAdapter;
-use Symfony\Component\Console\Output\OutputInterface;
+use Phinx\Db\Adapter\AdapterFactory;
 use Phinx\Db\Adapter\AdapterInterface;
-use Phinx\Db\Adapter\MysqlAdapter;
-use Phinx\Db\Adapter\PostgresAdapter;
-use Phinx\Db\Adapter\SQLiteAdapter;
-use Phinx\Db\Adapter\ProxyAdapter;
-use Phinx\Db\Adapter\TablePrefixAdapter;
 use Phinx\Migration\MigrationInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Environment
 {
@@ -66,11 +61,6 @@ class Environment
     protected $schemaTableName = 'phinxlog';
 
     /**
-     * @var callable[] AdapterInterface factory closures
-     */
-    protected $adapterFactories = array();
-
-    /**
      * @var AdapterInterface
      */
     protected $adapter;
@@ -86,27 +76,6 @@ class Environment
     {
         $this->name = $name;
         $this->options = $options;
-
-        foreach (static::defaultAdapterFactories() as $adapterName => $adapterFactoryClosure) {
-            $this->registerAdapter($adapterName, $adapterFactoryClosure);
-        }
-    }
-
-    /**
-     * You can register new adapter types, by passing a closure which
-     * instantiates and returns an implementation of `AdapterInterface`.
-     *
-     * @param string    $adapterName
-     * @param callable  $adapterFactoryClosure A closure which accepts an Environment parameter and returns an AdapterInterface implementation
-     */
-    public function registerAdapter($adapterName, $adapterFactoryClosure)
-    {
-        // TODO When 5.3 support is dropped, the `callable` type hint should be
-        // added to the $adapterFactoryClosure parameter, and this test can be removed.
-        if (!is_callable($adapterFactoryClosure)) {
-            throw new \RuntimeException('Provided adapter factory must be callable and return an object implementing AdapterInterface.');
-        }
-        $this->adapterFactories[$adapterName] = $adapterFactoryClosure;
     }
 
     /**
@@ -132,7 +101,8 @@ class Environment
             if ($direction == MigrationInterface::DOWN) {
                 // Create an instance of the ProxyAdapter so we can record all
                 // of the migration commands for reverse playback
-                $proxyAdapter = new ProxyAdapter($this->getAdapter());
+                $proxyAdapter = AdapterFactory::instance()
+                    ->getWrapper('proxy', $this->getAdapter());
                 $migration->setAdapter($proxyAdapter);
                 /** @noinspection PhpUndefinedMethodInspection */
                 $migration->change();
@@ -296,23 +266,23 @@ class Environment
         if (!isset($this->options['adapter'])) {
             throw new \RuntimeException('No adapter was specified for environment: ' . $this->getName());
         }
-        if (!isset($this->adapterFactories[$this->options['adapter']])) {
-            throw new \RuntimeException('Invalid adapter specified: ' . $this->options['adapter']);
+
+        $adapter = AdapterFactory::instance()
+            ->getAdapter($this->options['adapter'], $this->options);
+
+        if ($this->getOutput()) {
+            $adapter->setOutput($this->getOutput());
         }
 
-        // Get the adapter factory, get the adapter, check the type, and return
-        $adapterFactory = $this->adapterFactories[$this->options['adapter']];
-        $adapter = $adapterFactory($this);
-        if (!$adapter instanceof AdapterInterface) {
-            throw new \RuntimeException('Adapter factory closure did not return an instance of \\Phinx\\Db\\Adapter\\AdapterInterface');
-        }
-        
         // Use the TablePrefixAdapter if table prefix/suffixes are in use
         if ($adapter->hasOption('table_prefix') || $adapter->hasOption('table_suffix')) {
-            $adapter = new TablePrefixAdapter($adapter);
+            $adapter = AdapterFactory::instance()
+                ->getWrapper('prefix', $adapter);
         }
-        
-        return $this->adapter = $adapter;
+
+        $this->setAdapter($adapter);
+
+        return $adapter;
     }
 
     /**
@@ -335,26 +305,5 @@ class Environment
     public function getSchemaTableName()
     {
         return $this->schemaTableName;
-    }
-
-    /**
-     * @return callable[] Array of factory closures for Phinx's default adapter implementations.
-     */
-    public static final function defaultAdapterFactories()
-    {
-        return array(
-            'mysql'     => function(Environment $env) {
-                return new MysqlAdapter($env->getOptions(), $env->getOutput());
-            },
-            'pgsql'     => function(Environment $env) {
-                return new PostgresAdapter($env->getOptions(), $env->getOutput());
-            },
-            'sqlite'    => function(Environment $env) {
-                return new SQLiteAdapter($env->getOptions(), $env->getOutput());
-            },
-            'sqlsrv'    => function(Environment $env) {
-                return new SqlServerAdapter($env->getOptions(), $env->getOutput());
-            },
-        );
     }
 }

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Test\Phinx\Db\Adapter;
+
+use Phinx\Db\Adapter\AdapterFactory;
+
+class AdapterFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Phinx\Db\Adapter\AdapterFactory
+     */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->factory = AdapterFactory::instance();
+    }
+
+    public function tearDown()
+    {
+        unset($this->factory);
+    }
+
+    public function testInstanceIsFactory()
+    {
+        $this->assertInstanceOf('Phinx\Db\Adapter\AdapterFactory', $this->factory);
+    }
+
+    public function testRegisterAdapter()
+    {
+        // AdapterFactory::getClass is protected, work around it to avoid
+        // creating unnecessary instances and making the test more complex.
+        $method = new \ReflectionMethod(get_class($this->factory), 'getClass');
+        $method->setAccessible(true);
+
+        $adapter = $method->invoke($this->factory, 'mysql');
+        $this->factory->registerAdapter('test', $adapter);
+
+        $this->assertEquals($adapter, $method->invoke($this->factory, 'test'));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Adapter class "Test\Phinx\Db\Adapter\AdapterFactoryTest" must be implement Phinx\Db\Adapter\AdapterInterface
+     */
+    public function testRegisterAdapterFailure()
+    {
+        $adapter = get_class($this);
+        $this->factory->registerAdapter('test', $adapter);
+    }
+
+    public function testGetAdapter()
+    {
+        $adapter = $this->factory->getAdapter('mysql', array());
+
+        $this->assertInstanceOf('Phinx\Db\Adapter\MysqlAdapter', $adapter);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Adapter "bad" has not been registered
+     */
+    public function testGetAdapterFailure()
+    {
+        $this->factory->getAdapter('bad', array());
+    }
+
+    public function testRegisterWrapper()
+    {
+        // WrapperFactory::getClass is protected, work around it to avoid
+        // creating unnecessary instances and making the test more complex.
+        $method = new \ReflectionMethod(get_class($this->factory), 'getWrapperClass');
+        $method->setAccessible(true);
+
+        $wrapper = $method->invoke($this->factory, 'proxy');
+        $this->factory->registerWrapper('test', $wrapper);
+
+        $this->assertEquals($wrapper, $method->invoke($this->factory, 'test'));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Wrapper class "Test\Phinx\Db\Adapter\AdapterFactoryTest" must be implement Phinx\Db\Adapter\WrapperInterface
+     */
+    public function testRegisterWrapperFailure()
+    {
+        $wrapper = get_class($this);
+        $this->factory->registerWrapper('test', $wrapper);
+    }
+
+    private function getAdapterMock()
+    {
+        return $this->getMock('Phinx\Db\Adapter\AdapterInterface', array());
+    }
+
+    public function testGetWrapper()
+    {
+        $wrapper = $this->factory->getWrapper('prefix', $this->getAdapterMock());
+
+        $this->assertInstanceOf('Phinx\Db\Adapter\TablePrefixAdapter', $wrapper);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Wrapper "nope" has not been registered
+     */
+    public function testGetWrapperFailure()
+    {
+        $this->factory->getWrapper('nope', $this->getAdapterMock());
+    }
+}


### PR DESCRIPTION
Builds on #428 by creating a `AdapterFactory` that can be used at any time during application bootstrapping to inject or replace adapters with different classes. This makes it much easier to customize Phinx without direct modification.