### PR TITLE
ability to rollback an individual migration without migrations that have...

### DIFF
--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -45,13 +45,17 @@ class Rollback extends AbstractCommand
 
         $this->setName('rollback')
              ->setDescription('Rollback the last or to a specific migration')
+             ->addOption('--individual', '-i', InputOption::VALUE_OPTIONAL, 'An individual migration to roll back')
              ->addOption('--target', '-t', InputOption::VALUE_REQUIRED, 'The version number to rollback to')
              ->setHelp(
 <<<EOT
-The <info>rollback</info> command reverts the last migration, or optionally up to a specific version
+The <info>rollback</info> command reverts the last migration, or optionally up to a specific version.
+
+Using -i will rollback a single, individual migration.
 
 <info>phinx rollback -e development</info>
 <info>phinx rollback -e development -t 20111018185412</info>
+<info>phinx rollback -e development -t 20111018185412 -i</info>
 <info>phinx rollback -e development -v</info>
 
 EOT
@@ -71,6 +75,7 @@ EOT
 
         $environment = $input->getOption('environment');
         $version = $input->getOption('target');
+        $individual = $this->getOption('individual')
 
         if (null === $environment) {
             $environment = $this->getConfig()->getDefaultEnvironment();
@@ -90,7 +95,7 @@ EOT
 
         // rollback the specified environment
         $start = microtime(true);
-        $this->getManager()->rollback($environment, $version);
+        $this->getManager()->rollback($environment, $version, $individual == true);
         $end = microtime(true);
 
         $output->writeln('');

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -225,7 +225,7 @@ class Manager
      * @param int $version
      * @return void
      */
-    public function rollback($environment, $version = null)
+    public function rollback($environment, $version = null, $individual = false)
     {
         $migrations = $this->getMigrations();
         $env = $this->getEnvironment($environment);
@@ -235,7 +235,7 @@ class Manager
         sort($versions);
 
         // Check we have at least 1 migration to revert
-        if (empty($versions) || $version == end($versions)) {
+        if (empty($versions)) {
             $this->getOutput()->writeln('<error>No migrations to rollback</error>');
             return;
         }
@@ -252,6 +252,14 @@ class Manager
             // If the target version is before the first migration, revert all migrations
             if ($version < $first) {
                 $version = 0;
+            }
+        }
+
+        if($individual) {
+            $migration = $migrations[$version];
+            if (in_array($migration->getVersion(), $versions)) {                
+                $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                return;
             }
         }
 

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -79,6 +79,54 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
     }
 
+    public function testExecuteWithVersionOption()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Rollback());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub->expects($this->once())
+                    ->method('rollback')
+                    ->with('fakeenv', '283492874');
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv', '--target' => '283492874'));
+        $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithIndividualVersionOption()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Rollback());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub->expects($this->once())
+                    ->method('rollback')
+                    ->with('fakeenv', '283492874', true);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv', '--target' => '283492874', '--individual' => 'true'));
+        $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
+    }
+
     public function testDatabaseNameSpecified()
     {
         $application = new \Phinx\Console\PhinxApplication('testing');


### PR DESCRIPTION
... happened after it

There are some situations where migrations may happen out of order of they they are written, this change allows single migrations to be reverted on an individual basis.