### PR TITLE
Added jsonb support for postgresql 9.4

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -56,6 +56,7 @@ interface AdapterInterface
     const PHINX_TYPE_BINARY         = 'binary';
     const PHINX_TYPE_BOOLEAN        = 'boolean';
     const PHINX_TYPE_JSON           = 'json';
+    const PHINX_TYPE_JSONB          = 'jsonb';
     const PHINX_TYPE_UUID           = 'uuid';
     const PHINX_TYPE_FILESTREAM     = 'filestream';
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -690,6 +690,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             case static::PHINX_TYPE_DATE:
             case static::PHINX_TYPE_BOOLEAN:
             case static::PHINX_TYPE_JSON:
+            case static::PHINX_TYPE_JSONB:
             case static::PHINX_TYPE_UUID:
                 return array('name' => $type);
             case static::PHINX_TYPE_STRING:
@@ -747,6 +748,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 return static::PHINX_TYPE_CHAR;
             case 'text':
             case 'json':
+            case 'jsonb':
                 return static::PHINX_TYPE_TEXT;
             case 'int':
             case 'int4':
@@ -1077,7 +1079,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function getColumnTypes()
     {
-        return array_merge(parent::getColumnTypes(), array('json', 'uuid'));
+        return array_merge(parent::getColumnTypes(), array('json', 'uuid', 'jsonb'));
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -747,9 +747,11 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             case 'char':
                 return static::PHINX_TYPE_CHAR;
             case 'text':
-            case 'json':
-            case 'jsonb':
                 return static::PHINX_TYPE_TEXT;
+            case 'json':
+                return static::PHINX_TYPE_JSON;
+            case 'jsonb':
+                return static::PHINX_TYPE_JSONB;
             case 'int':
             case 'int4':
             case 'integer':


### PR DESCRIPTION
PostgreSQL 9.4 added [jsonb](http://www.postgresql.org/docs/9.4/static/datatype-json.html) type support. This allows for json stores to be indexed by the engine.