### PR TITLE
Add support for UUID in Mysql and Sqlite

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -787,6 +787,8 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             case static::PHINX_TYPE_BOOLEAN:
                 return array('name' => 'tinyint', 'limit' => 1);
                 break;
+            case static::PHINX_TYPE_UUID:
+                return array('name' => 'char', 'limit' => 36);
             // Geospatial database types
             case static::PHINX_TYPE_GEOMETRY:
             case static::PHINX_TYPE_POINT:
@@ -836,6 +838,9 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                     $type = static::PHINX_TYPE_CHAR;
                     if ($limit === 255) {
                         $limit = null;
+                    }
+                    if ($limit === 36) {
+                        $type = static::PHINX_TYPE_UUID;
                     }
                     break;
                 case 'tinyint':

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -432,6 +432,7 @@ abstract class PdoAdapter implements AdapterInterface
             'date',
             'binary',
             'boolean',
+            'uuid',
             // Geospatial data types
             'geometry',
             'point',

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1077,7 +1077,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function getColumnTypes()
     {
-        return array_merge(parent::getColumnTypes(), array('json', 'uuid'));
+        return array_merge(parent::getColumnTypes(), array('json'));
     }
 
     /**

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -834,6 +834,8 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             case static::PHINX_TYPE_BOOLEAN:
                 return array('name' => 'boolean');
                 break;
+            case static::PHINX_TYPE_UUID:
+                return array('name' => 'char', 'limit' => 36);
             // Geospatial database types
             // No specific data types exist in SQLite, instead all geospatial
             // functionality is handled in the client. See also: SpatiaLite.
@@ -882,6 +884,9 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                     $type = static::PHINX_TYPE_CHAR;
                     if ($limit == 255) {
                         $limit = null;
+                    }
+                    if ($limit === 36) {
+                        $type = static::PHINX_TYPE_UUID;
                     }
                     break;
                 case 'int':

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1142,23 +1142,7 @@ SQL;
      */
     public function getColumnTypes()
     {
-        return array(
-            'string',
-            'text',
-            'char',
-            'integer',
-            'biginteger',
-            'float',
-            'decimal',
-            'datetime',
-            'timestamp',
-            'time',
-            'date',
-            'binary',
-            'boolean',
-            'uuid',
-            'filestream'
-        );
+        return array_merge(parent::getColumnTypes(), array('filestream'));
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -575,7 +575,8 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
               ->addColumn('column16', 'geometry')
               ->addColumn('column17', 'point')
               ->addColumn('column18', 'linestring')
-              ->addColumn('column19', 'polygon');
+              ->addColumn('column19', 'polygon')
+              ->addColumn('column20', 'uuid');
         $pendingColumns = $table->getPendingColumns();
         $table->save();
         $columns = $this->adapter->getColumns('t');
@@ -619,7 +620,8 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
               ->addColumn('column16', 'geometry')
               ->addColumn('column17', 'point')
               ->addColumn('column18', 'linestring')
-              ->addColumn('column19', 'polygon');
+              ->addColumn('column19', 'polygon')
+              ->addColumn('column20', 'uuid');
         $pendingColumns = $table->getPendingColumns();
         $table->save();
         $columns = $this->adapter->getColumns('group');


### PR DESCRIPTION
Currently only SqlServer and PostgreSql support native UUID/UniqueIdentifier column types. This PR adds a mapping for Mysql and Sqlite to treat UUIDs as CHAR(36).

This allows for migration scripts originally written for SqlServer or PostgreSql to work without modification on Mysql/Sqlite.