### PR TITLE
Mysql binary should use LONGBLOB

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -782,7 +782,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'date');
                 break;
             case static::PHINX_TYPE_BINARY:
-                return array('name' => 'blob');
+                return array('name' => 'longblob');
                 break;
             case static::PHINX_TYPE_BOOLEAN:
                 return array('name' => 'tinyint', 'limit' => 1);
@@ -867,6 +867,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                     }
                     $type = static::PHINX_TYPE_BIG_INTEGER;
                     break;
+                case 'longblob':
                 case 'blob':
                     $type = static::PHINX_TYPE_BINARY;
                     break;


### PR DESCRIPTION
`BLOB` fields only supports 2^16 (65536) bytes, whereas `LONGBLOB` supports 2^32 bytes (4096 MiB).