### PR TITLE
Make quotes more ANSI compatible.

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -352,9 +352,9 @@ abstract class PdoAdapter implements AdapterInterface
                 'INSERT INTO %s ('
                 . 'version, start_time, end_time'
                 . ') VALUES ('
-                . '"%s",'
-                . '"%s",'
-                . '"%s"'
+                . '\'%s\','
+                . '\'%s\','
+                . '\'%s\''
                 . ');',
                 $this->getSchemaTableName(),
                 $migration->getVersion(),


### PR DESCRIPTION
Using double quotes for values is MySQL specific.  Running against
a MySQL server with ANSI_QUOTES mode set results in an inability to
record migrations in the database as the migration name value is
treated as a column name.

This change makes the use of single quotes more consistent with all
existing database drivers and more compatible with ANSI usage.

This is more of a bug fix than a feature and will close #453