### PR TITLE
Allow aliases for the template creation class names.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,6 +1,6 @@
 .. index::
    single: Configuration
-   
+
 Configuration
 =============
 
@@ -19,7 +19,7 @@ If you do not wish to use the default configuration file, you may specify a conf
 Migration Path
 --------------
 
-The first option specifies the path to your migration directory. Phinx uses 
+The first option specifies the path to your migration directory. Phinx uses
 ``%%PHINX_CONFIG_DIR%%/migrations`` by default.
 
 .. note::
@@ -191,7 +191,7 @@ Custom Adapters
 `````````````````
 
 You can provide a custom adapter by registering an implementation of the `Phinx\\Db\\Adapter\\AdapterInterface`
-with `AdapterFactory`: 
+with `AdapterFactory`:
 
 .. code-block:: php
 
@@ -202,3 +202,16 @@ with `AdapterFactory`:
 
 Adapters can be registered any time before `$app->run()` is called, which normally
 called by `bin/phinx`.
+
+Aliases
+-------
+
+Template creation class names can be aliased and used with the ``--class`` command line option for the :doc:`Create Command <commands>`.
+
+The aliased classes will still be required to implement the ``Phinx\Migration\CreationInterface`` interface.
+
+.. code-block:: yaml
+
+    aliases:
+        permission: \Namespace\Migrations\PermissionMigrationTemplateGenerator
+        view: \Namespace\Migrations\ViewMigrationTemplateGenerator

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -210,6 +210,17 @@ class Config implements ConfigInterface
     }
 
     /**
+     * Get the aliased value from a supplied alias.
+     *
+     * @param string $alias
+     *
+     * @return string|null
+     */
+    public function getAlias($alias){
+        return !empty($this->values['aliases'][$alias]) ? $this->values['aliases'][$alias] : null;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getConfigFilePath()

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -126,9 +126,10 @@ class Create extends AbstractCommand
             ));
         }
 
-        // Get the alternative template and static class options, but only allow one of them.
-        $altTemplate = $input->getOption('template');
+        // Get the alternative template and/or template creation class options, but only allow one of them.
+        $altTemplate       = $input->getOption('template');
         $creationClassName = $input->getOption('class');
+        $aliasedClassName  = null;
         if ($altTemplate && $creationClassName) {
             throw new \InvalidArgumentException('Cannot use --template and --class at the same time');
         }
@@ -141,22 +142,44 @@ class Create extends AbstractCommand
             ));
         }
 
-        // Verify the static class exists and that it implements the required interface.
+        // Verify that the template creation class (or the aliased class) exists and that it implements the required interface.
         if ($creationClassName) {
+            // Supplied class does not exist, is it aliased?
             if (!class_exists($creationClassName)) {
-                throw new \InvalidArgumentException(sprintf(
-                    'The class "%s" does not exist',
-                    $creationClassName
-                ));
+                $aliasedClassName = $this->getConfig()->getAlias($creationClassName);
+                if ($aliasedClassName && !class_exists($aliasedClassName)) {
+                    throw new \InvalidArgumentException(sprintf(
+                        'The class "%s" via the alias "%s" does not exist',
+                        $aliasedClassName,
+                        $creationClassName
+                    ));
+                } elseif (!$aliasedClassName) {
+                    throw new \InvalidArgumentException(sprintf(
+                        'The class "%s" does not exist',
+                        $creationClassName
+                    ));
+                }
             }
-            if (!is_subclass_of($creationClassName, self::CREATION_INTERFACE)) {
+
+            // Does the class implement the required interface?
+            if (!$aliasedClassName && !is_subclass_of($creationClassName, self::CREATION_INTERFACE)) {
                 throw new \InvalidArgumentException(sprintf(
                     'The class "%s" does not implement the required interface "%s"',
                     $creationClassName,
                     self::CREATION_INTERFACE
                 ));
+            } elseif ($aliasedClassName && !is_subclass_of($aliasedClassName, self::CREATION_INTERFACE)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'The class "%s" via the alias "%s" does not implement the required interface "%s"',
+                    $aliasedClassName,
+                    $creationClassName,
+                    self::CREATION_INTERFACE
+                ));
             }
         }
+
+        // Use the aliased class.
+        $creationClassName = $aliasedClassName ?: $creationClassName;
 
         // Determine the appropriate mechanism to get the template
         if ($creationClassName) {

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -156,4 +156,28 @@ class ConfigTest extends AbstractConfigTest
         $config = new Config(array('migration_base_class' => 'Phinx\Migration\AlternativeAbstractMigration'));
         $this->assertEquals('Phinx\Migration\AlternativeAbstractMigration', $config->getMigrationBaseClassName(false));
     }
+
+    public function testGetAliasNoAliasesEntry()
+    {
+        $config = new \Phinx\Config\Config(array());
+        $this->assertNull($config->getAlias('Short'));
+    }
+
+    public function testGetAliasEmptyAliasesEntry()
+    {
+        $config = new \Phinx\Config\Config(array('aliases'=> array()));
+        $this->assertNull($config->getAlias('Short'));
+    }
+
+    public function testGetAliasInvalidAliasRequest()
+    {
+        $config = new \Phinx\Config\Config(array('aliases'=> array('Medium' => 'Some\Long\Classname')));
+        $this->assertNull($config->getAlias('Short'));
+    }
+
+    public function testGetAliasValidAliasRequest()
+    {
+        $config = new \Phinx\Config\Config(array('aliases'=> array('Short' => 'Some\Long\Classname')));
+        $this->assertEquals('Some\Long\Classname', $config->getAlias('Short'));
+    }
 }


### PR DESCRIPTION
We have a set of migration template creation classes that are namespaced. Allowing them to be accessed via an alias which is part of our Phinx setup simplifies things for our developers.

One thing I wasn't sure about is making ```Config::getAlias()``` part of ```ConfigInterface```.

If I did, any pre-existing class implementing that interface will now require an empty function, assuming they didn't want to use any aliases.

So, hopefully, just where it is is OK.
