### PR TITLE
Add port information when using sqlsrv adapter

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -156,7 +156,7 @@ Declaring an SQLite database uses a simplified structure:
             memory: true     # Setting memory to *any* value overrides name
 
 When using the ``sqlsrv`` adapter and connecting to a named instance of 
-SQLServer you should omit the `port` setting as sqlsrv will negotiate the port
+SQLServer you should omit the ``port`` setting as sqlsrv will negotiate the port
 automatically.
 
 You can provide a custom adapter by registering an implementation of the `Phinx\\Db\\Adapter\\AdapterInterface`

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -155,6 +155,10 @@ Declaring an SQLite database uses a simplified structure:
             adapter: sqlite
             memory: true     # Setting memory to *any* value overrides name
 
+When using the ``sqlsrv`` adapter and connecting to a named instance of 
+SQLServer you should omit the `port` setting as sqlsrv will negotiate the port
+automatically.
+
 You can provide a custom adapter by registering an implementation of the `Phinx\\Db\\Adapter\\AdapterInterface`
 with `AdapterFactory`: 
 


### PR DESCRIPTION
Hi,

When using sqlsrv to connect to a named instance it had me searching for quite a while to find out that if you connect to an instance it will negotiate which port to use. So you need to omit the port in the configuration.