### PR TITLE
Postgres: fixed problem with changeColumn and default values

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -399,8 +399,11 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             $this->quoteColumnName($columnName),
             $this->getColumnSqlDefinition($newColumn)
         );
-        $sql = preg_replace('/ NOT NULL$/', '', $sql);
-        $sql = preg_replace('/ NULL$/', '', $sql);
+        //NULL and DEFAULT cannot be set while changing column type
+        $sql = preg_replace('/ NOT NULL/', '', $sql);
+        $sql = preg_replace('/ NULL/', '', $sql);
+        //If it is set, DEFAULT is the last definition
+        $sql = preg_replace('/DEFAULT .*/', '', $sql);
         $this->execute($sql);
         // process null
         $sql = sprintf(
@@ -414,6 +417,27 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             $sql .= ' SET NOT NULL';
         }
         $this->execute($sql);
+        if (!is_null($newColumn->getDefault())) {
+            //change default
+            $this->execute(
+                sprintf(
+                    'ALTER TABLE %s ALTER COLUMN %s SET %s',
+                    $this->quoteTableName($tableName),
+                    $this->quoteColumnName($columnName),
+                    $this->getDefaultValueDefinition($newColumn->getDefault())
+                )
+            );
+        }
+        else {
+            //drop default
+            $this->execute(
+                sprintf(
+                    'ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT',
+                    $this->quoteTableName($tableName),
+                    $this->quoteColumnName($columnName)
+                )
+            );
+        }
         // rename column
         if ($columnName !== $newColumn->getName()) {
             $this->execute(

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -350,6 +350,54 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
             if ($column->getName() == 'column2') {
                 $this->assertTrue($column->isNull());
             }
+        }        
+    }
+
+    public function testChangeColumnWithDefault() {
+        $table = new \Phinx\Db\Table('t', array(), $this->adapter);
+        $table->addColumn('column1', 'string')
+              ->save();
+
+        $newColumn1 = new \Phinx\Db\Table\Column();
+        $newColumn1->setName('column1')
+                   ->setType('string')
+                   ->setNull(true);
+
+        $newColumn1->setDefault('Test');
+        $table->changeColumn('column1', $newColumn1);
+
+        $columns = $this->adapter->getColumns('t');
+        foreach ($columns as $column) {
+            if ($column->getName() === 'column1') {
+                $this->assertTrue($column->isNull());
+                $this->assertRegExp('/Test/', $column->getDefault());
+            }
+        }
+    }
+
+    public function testChangeColumnWithDropDefault() {
+        $table = new \Phinx\Db\Table('t', array(), $this->adapter);
+        $table->addColumn('column1', 'string', array('default' => 'Test'))
+              ->save();
+
+        $columns = $this->adapter->getColumns('t');
+        foreach ($columns as $column) {
+            if ($column->getName() === 'column1') {
+                $this->assertRegExp('/Test/', $column->getDefault());
+            }
+        }
+
+        $newColumn1 = new \Phinx\Db\Table\Column();
+        $newColumn1->setName('column1')
+                   ->setType('string');
+
+        $table->changeColumn('column1', $newColumn1);
+
+        $columns = $this->adapter->getColumns('t');
+        foreach ($columns as $column) {
+            if ($column->getName() === 'column1') {
+                $this->assertNull($column->getDefault());
+            }
         }
     }
 


### PR DESCRIPTION
When trying to change the default value in the changeColumn method a syntax error occurred.
Added the ability to drop the default constraint by leaving default null.