### PR TITLE
Postgres Adaptor Support for JSONB and BIGSERIAL

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -416,7 +416,7 @@ Column types are specified as strings and can be one of:
 
 In addition, the MySQL adapter supports ``enum`` and ``set`` column types.
 
-In addition, the Postgres adapter supports ``json`` and ``uuid`` column types
+In addition, the Postgres adapter supports ``json``, ``jsonb``, ``bigserial``, and ``uuid`` column types
 (PostgreSQL 9.3 and above).
 
 For valid options, see the `Valid Column Options`_ below.

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -401,22 +401,29 @@ Valid Column Types
 
 Column types are specified as strings and can be one of: 
 
--  string
--  text
--  integer
 -  biginteger
--  float
--  decimal
--  datetime
--  timestamp
--  time
--  date
 -  binary
 -  boolean
+-  date
+-  datetime
+-  decimal
+-  float
+-  integer
+-  string
+-  text
+-  timestamp
+-  time
 
 In addition, the MySQL adapter supports ``enum`` and ``set`` column types.
 
-In addition, the Postgres adapter supports ``json``, ``jsonb``, ``bigserial``, and ``uuid`` column types
+In addition, the Postgres adapter supports these additional column types:
+
+- bigserial
+- json
+- jsonb
+- inet
+- uuid
+
 (PostgreSQL 9.3 and above).
 
 For valid options, see the `Valid Column Options`_ below.

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -60,6 +60,7 @@ interface AdapterInterface
     const PHINX_TYPE_UUID           = 'uuid';
     const PHINX_TYPE_FILESTREAM     = 'filestream';
     const PHINX_TYPE_BIGSERIAL      = 'bigserial';
+    const PHINX_TYPE_INET           = 'inet';
 
     // Geospatial database types
     const PHINX_TYPE_GEOMETRY       = 'geometry';

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -56,8 +56,10 @@ interface AdapterInterface
     const PHINX_TYPE_BINARY         = 'binary';
     const PHINX_TYPE_BOOLEAN        = 'boolean';
     const PHINX_TYPE_JSON           = 'json';
+    const PHINX_TYPE_JSONB          = 'jsonb';
     const PHINX_TYPE_UUID           = 'uuid';
     const PHINX_TYPE_FILESTREAM     = 'filestream';
+    const PHINX_TYPE_BIGSERIAL      = 'bigserial';
 
     // Geospatial database types
     const PHINX_TYPE_GEOMETRY       = 'geometry';

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -440,6 +440,7 @@ abstract class PdoAdapter implements AdapterInterface
             'polygon',
             'jsonb',
             'bigserial',
+            'inet',
         );
     }
 

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -438,6 +438,8 @@ abstract class PdoAdapter implements AdapterInterface
             'point',
             'linestring',
             'polygon',
+            'jsonb',
+            'bigserial',
         );
     }
 

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -438,9 +438,6 @@ abstract class PdoAdapter implements AdapterInterface
             'point',
             'linestring',
             'polygon',
-            'jsonb',
-            'bigserial',
-            'inet',
         );
     }
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -752,6 +752,8 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 return static::PHINX_TYPE_JSONB;
             case 'bigserial':
                 return static::PHINX_TYPE_BIGSERIAL;
+            case 'inet':
+                return static::PHINX_TYPE_INET;
             case 'int':
             case 'int4':
             case 'integer':

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1083,7 +1083,13 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function getColumnTypes()
     {
-        return array_merge(parent::getColumnTypes(), array('json'));
+        $types = parent::getColumnTypes();
+        return array_merge(parent::getColumnTypes(), array(
+            'json'
+            'jsonb',
+            'bigserial',
+            'inet',
+        ));
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1085,7 +1085,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     {
         $types = parent::getColumnTypes();
         return array_merge(parent::getColumnTypes(), array(
-            'json'
+            'json',
             'jsonb',
             'bigserial',
             'inet',

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -748,6 +748,10 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             case 'text':
             case 'json':
                 return static::PHINX_TYPE_TEXT;
+            case 'jsonb':
+                return static::PHINX_TYPE_JSONB;
+            case 'bigserial':
+                return static::PHINX_TYPE_BIGSERIAL;
             case 'int':
             case 'int4':
             case 'integer':

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -690,6 +690,9 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             case static::PHINX_TYPE_DATE:
             case static::PHINX_TYPE_BOOLEAN:
             case static::PHINX_TYPE_JSON:
+            case static::PHINX_TYPE_JSONB:
+            case static::PHINX_TYPE_BIGSERIAL:
+            case static::PHINX_TYPE_INET:
             case static::PHINX_TYPE_UUID:
                 return array('name' => $type);
             case static::PHINX_TYPE_STRING:

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -585,6 +585,7 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('jsonb', $this->adapter->getPhinxType('jsonb'));
         $this->assertEquals('bigserial', $this->adapter->getPhinxType('bigserial'));
+        $this->assertEquals('inet', $this->adapter->getPhinxType('inet'));
 
     }
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -583,6 +583,9 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('uuid', $this->adapter->getPhinxType('uuid'));
 
+        $this->assertEquals('jsonb', $this->adapter->getPhinxType('jsonb'));
+        $this->assertEquals('bigserial', $this->adapter->getPhinxType('bigserial'));
+
     }
 
     public function testCanAddColumnComment()


### PR DESCRIPTION
This PR fixes issue #482 with test and documentation. 

Recap: Postgres adaptor does not current support JSONB, Postgres 9.4, nor BIGSERIAL, ~8.1. This PR fixes those.