### PR TITLE
Added table name as part of index for SQLite adapter

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -568,7 +568,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         $this->execute(
             sprintf(
                 'CREATE %s ON %s (%s)',
-                $this->getIndexSqlDefinition($index),
+                $this->getIndexSqlDefinition($table, $index),
                 $this->quoteTableName($table->getName()),
                 $indexColumns
             )
@@ -1025,7 +1025,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      * @param Index $index Index
      * @return string
      */
-    protected function getIndexSqlDefinition(Index $index)
+    protected function getIndexSqlDefinition(Table $table, Index $index)
     {
         if ($index->getType() == Index::UNIQUE) {
             $def = 'UNIQUE INDEX';
@@ -1035,7 +1035,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         if (is_string($index->getName())) {
             $indexName = $index->getName();
         } else {
-            $indexName = '';
+            $indexName = $table->getName() . '_';
             foreach ($index->getColumns() as $column) {
                 $indexName .= $column . '_';
             }


### PR DESCRIPTION
The SQLite adapter uses named indexes (assuming because SQLite needs named indexes), and the current implementation does not use table name as part of the index. This patch changes that.

When two tables define an index on a field with the same name, only one of the indexes is created. No errors are given from Phinx in this case.

A work-around is to use named indexes. (i.e. addIndex(array("field"), array("name" => "my_index")) ).

I've executed the tests after making the change, hoping it won't break anything, let me know if more is required :-)
