### PR TITLE
Added test for two indexes with same name in different tables, SQLite.

### DIFF
--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -502,4 +502,27 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\RuntimeException','Column type ?int? is not supported');
         $this->adapter->getPhinxType('?int?');
     }
+
+
+    public function testAddIndexTwoTablesSameIndex()
+    {
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->addColumn('email', 'string')
+              ->save();
+        $table2 = new \Phinx\Db\Table('table2', array(), $this->adapter);
+        $table2->addColumn('email', 'string')
+               ->save();
+
+        $this->assertFalse($table->hasIndex('email'));
+        $this->assertFalse($table2->hasIndex('email'));
+
+        $table->addIndex('email')
+              ->save();
+        $table2->addIndex('email')
+               ->save();
+
+        $this->assertTrue($table->hasIndex('email'));
+        $this->assertTrue($table2->hasIndex('email'));
+    }
+
 }


### PR DESCRIPTION
This is the test for the previous patch. Two tables with same indexed attribute in SQLite.