### PR TITLE
No prev migration check on rollback

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -253,7 +253,7 @@ class Manager
                 }
             }
 
-            exit();
+            return;
         } else {
             // Get the first migration number
             $first = reset($versions);

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -246,13 +246,19 @@ class Manager
 
             $this->getOutput()->writeln('<info>Attempting to rollback version: </info><comment>' . $version . '</comment>');
 
+            $migration_found = false;
+
             foreach ($migrations as $migration){
                 if ($migration->getVersion() == $version) {
-                  $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
-                  break;
+                    $migration_found = true;
+                    $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                    break;
                 }
             }
 
+            if(!$migration_found) {
+              $this->getOutput()->writeln('<error>Migration for version: ' . $version . ' not found.</error>');
+            }
             return;
         } else {
             // Get the first migration number

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -246,13 +246,11 @@ class Manager
 
             $this->getOutput()->writeln('<info>Attempting to rollback version: </info><comment>' . $version . '</comment>');
 
-            foreach ($migrations as $migration)
-            {
-              if ($migration->getVersion() == $version)
-              {
-                $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
-                break;
-              }
+            foreach ($migrations as $migration){
+                if ($migration->getVersion() == $version) {
+                  $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                  break;
+                }
             }
 
             exit();

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -242,7 +242,6 @@ class Manager
 
         // If no target version was supplied, revert the last migration and exit
         if (null === $version) {
-            // Get the migration before the last run migration
             $version = end($versions);
 
             $this->getOutput()->writeln('<info>Attempting to rollback version: </info><comment>' . $version . '</comment>');

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -240,11 +240,23 @@ class Manager
             return;
         }
 
-        // If no target version was supplied, revert the last migration
+        // If no target version was supplied, revert the last migration and exit
         if (null === $version) {
             // Get the migration before the last run migration
-            $prev = count($versions) - 2;
-            $version = $prev >= 0 ? $versions[$prev] : 0;
+            $version = end($versions);
+
+            $this->getOutput()->writeln('<info>Attempting to rollback version: </info><comment>' . $version . '</comment>');
+
+            foreach ($migrations as $migration)
+            {
+              if ($migration->getVersion() == $version)
+              {
+                $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                break;
+              }
+            }
+
+            exit();
         } else {
             // Get the first migration number
             $first = reset($versions);


### PR DESCRIPTION
When a team is working on various branches, a situation can arise where rolling back the most recent migration means the previous migration doesn't exist, because it was executed when another branch was checked out. It seems logical to me that executing a rollback with no target should not fail if the previous migration doesn't exist on the current branch, as no action is being taken on that previous migration.

This change executes the rollback of the most recent migration, without checking for the existence of the previous migration.