### PR TITLE
Support for smallint to PostgreSQL database

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -416,7 +416,7 @@ Column types are specified as strings and can be one of:
 
 In addition, the MySQL adapter supports ``enum`` and ``set`` column types.
 
-In addition, the Postgres adapter supports ``json`` and ``uuid`` column types
+In addition, the Postgres adapter supports ``smallint``, ``json`` and ``uuid`` column types
 (PostgreSQL 9.3 and above).
 
 For valid options, see the `Valid Column Options`_ below.
@@ -909,6 +909,30 @@ delete set an action to be triggered when the row is deleted
 
 You can pass one or more of these options to any column with the optional
 third argument array.
+
+Limit Option and PostgreSQL
+~~~~~~~~~~~~~~~~~~~~~~
+
+When using the PostgreSQL adapter, additional hinting of database column type can be
+made for ``integer`` columns. Using ``limit`` with one the following options will
+modify the column type accordingly:
+
+============ ==============
+Limit        Column Type
+============ ==============
+INT_SMALL    SMALLINT
+============ ==============
+
+.. code-block:: php
+
+         use Phinx\Db\Adapter\PostgresAdapter;
+   
+         //...
+   
+         $table = $this->table('cart_items');
+         $table->addColumn('user_id', 'integer')
+               ->addColumn('subtype_id', 'integer', array('limit' => PostgresAdapter::INT_SMALL))
+               ->create();
 
 Limit Option and MySQL
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -787,7 +787,6 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                     'limit' => static::INT_SMALL
                 );
             case 'int':
-            case 'int2':
             case 'int4':
             case 'integer':
                 return static::PHINX_TYPE_INTEGER;

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -415,18 +415,19 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
         $table->addColumn('column1', 'string')
-              ->addColumn('column2', 'integer')
-              ->addColumn('column3', 'biginteger')
-              ->addColumn('column4', 'text')
-              ->addColumn('column5', 'float')
-              ->addColumn('column6', 'decimal')
-              ->addColumn('column7', 'time')
-              ->addColumn('column8', 'timestamp')
-              ->addColumn('column9', 'date')
-              ->addColumn('column10', 'boolean')
-              ->addColumn('column11', 'datetime')
-              ->addColumn('column12', 'binary')
-              ->addColumn('column13', 'string', array('limit' => 10));
+              ->addColumn('column2', 'integer', array('limit' => PostgresAdapter::INT_SMALL))
+              ->addColumn('column3', 'integer')
+              ->addColumn('column4', 'biginteger')
+              ->addColumn('column5', 'text')
+              ->addColumn('column6', 'float')
+              ->addColumn('column7', 'decimal')
+              ->addColumn('column8', 'time')
+              ->addColumn('column9', 'timestamp')
+              ->addColumn('column10', 'date')
+              ->addColumn('column11', 'boolean')
+              ->addColumn('column12', 'datetime')
+              ->addColumn('column13', 'binary')
+              ->addColumn('column14', 'string', array('limit' => 10));
         $pendingColumns = $table->getPendingColumns();
         $table->save();
         $columns = $this->adapter->getColumns('t');
@@ -599,6 +600,7 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
     public function testGetPhinxType()
     {
         $this->assertEquals('integer', $this->adapter->getPhinxType('int'));
+        $this->assertEquals('integer', $this->adapter->getPhinxType('int2'));
         $this->assertEquals('integer', $this->adapter->getPhinxType('int4'));
         $this->assertEquals('integer', $this->adapter->getPhinxType('integer'));
 

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -600,7 +600,6 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
     public function testGetPhinxType()
     {
         $this->assertEquals('integer', $this->adapter->getPhinxType('int'));
-        $this->assertEquals('integer', $this->adapter->getPhinxType('int2'));
         $this->assertEquals('integer', $this->adapter->getPhinxType('int4'));
         $this->assertEquals('integer', $this->adapter->getPhinxType('integer'));
 


### PR DESCRIPTION
Added support for numeric columns of type smallint similarly the implementation of column types used in the version of MySQL.

Updated the documentation with the content of the changes made.

Implemented unit testing.