### PR TITLE
SQLiteAdapter fixes for transaction, createTable() with foreign key and addForeignKey()

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -217,8 +217,6 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             $sql = substr(rtrim($sql), 0, -1);              // no primary keys
         }
 
-        $sql .= ') ';
-
         // set the foreign keys
         $foreignKeys = $table->getForeignKeys();
         if (!empty($foreignKeys)) {
@@ -227,7 +225,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             }
         }
 
-        $sql = rtrim($sql) . ';';
+        $sql = rtrim($sql) . ');';
         // execute the sql
         $this->writeCommand('createTable', array($table->getName()));
         $this->execute($sql);

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -109,7 +109,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
      */
     public function beginTransaction()
     {
-        $this->execute('START TRANSACTION');
+        $this->execute('BEGIN TRANSACTION');
     }
 
     /**

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -702,9 +702,9 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             }
         }
 
-        $this->fetchAll(sprintf('pragma table_info(%s)', $this->quoteTableName($table->getName())));
+        $rows = $this->fetchAll(sprintf('pragma table_info(%s)', $this->quoteTableName($table->getName())));
         $columns = array();
-        foreach ($columns as $column) {
+        foreach ($rows as $column) {
             $columns[] = $this->quoteColumnName($column['name']);
         }
 
@@ -715,10 +715,10 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
 
         $sql = sprintf(
             'INSERT INTO %s(%s) SELECT %s FROM %s',
-            $table->getName(),
+            $this->quoteTableName($table->getName()),
             implode(', ', $columns),
             implode(', ', $columns),
-            $tmpTableName
+            $this->quoteTableName($tmpTableName)
         );
 
         $this->execute($sql);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -455,6 +455,24 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), array('ref_table_id')));
     }
 
+    public function testAddForeignKeyWithPdoExceptionErrorMode()
+    {
+        $this->adapter->getConnection()
+            ->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $refTable = new \Phinx\Db\Table('ref_table', array(), $this->adapter);
+        $refTable->addColumn('field1', 'string')->save();
+
+        $table = new \Phinx\Db\Table('table', array(), $this->adapter);
+        $table->addColumn('ref_table_id', 'integer')->save();
+
+        $fk = new \Phinx\Db\Table\ForeignKey();
+        $fk->setReferencedTable($refTable)
+            ->setColumns(array('ref_table_id'))
+            ->setReferencedColumns(array('id'));
+
+        $this->adapter->addForeignKey($table, $fk);
+    }
+
     public function testDropForeignKey()
     {
         $refTable = new \Phinx\Db\Table('ref_table', array(), $this->adapter);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -471,6 +471,8 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
             ->setReferencedColumns(array('id'));
 
         $this->adapter->addForeignKey($table, $fk);
+
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), array('ref_table_id')));
     }
 
     public function testDropForeignKey()

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -41,6 +41,13 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->adapter->getConnection() instanceof \PDO);
     }
 
+    public function testBeginTransaction()
+    {
+        $this->adapter->getConnection()
+            ->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $this->adapter->beginTransaction();
+    }
+
     public function testCreatingTheSchemaTableOnConnect()
     {
         $this->adapter->connect();

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -167,6 +167,20 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete();
     }
 
+    public function testCreateTableWithForeignKey()
+    {
+        $refTable = new \Phinx\Db\Table('ref_table', array(), $this->adapter);
+        $refTable->addColumn('field1', 'string')->save();
+
+        $table = new \Phinx\Db\Table('table', array(), $this->adapter);
+        $table->addColumn('ref_table_id', 'integer');
+        $table->addForeignKey('ref_table_id', 'ref_table', 'id');
+        $table->save();
+
+        $this->assertTrue($this->adapter->hasTable($table->getName()));
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), array('ref_table_id')));
+    }
+
     public function testRenameTable()
     {
         $table = new \Phinx\Db\Table('table1', array(), $this->adapter);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -46,6 +46,8 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $this->adapter->getConnection()
             ->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $this->adapter->beginTransaction();
+
+        $this->assertTrue(true, 'Transaction query succeeded');
     }
 
     public function testCreatingTheSchemaTableOnConnect()


### PR DESCRIPTION
This PR contains the following three fixes within the SQLiteAdapter:

#### beginTransaction
Fixed `beginTransaction()` query. It now uses `BEGIN TRANSACTION` (see: https://www.sqlite.org/lang_transaction.html). Using `START TRANSACTION` with PDO error mode set to exception/error (see http://php.net/manual/en/pdo.error-handling.php) will result in an error. Added `testBeginTransaction` test.

#### createTable with foreign key
Fixed erroneous create table query in `createTable()` when the table has one or more foreign keys.
`createTable()` now adds the foreign key statements to the column definitions, inside the parentheses, instead of after (see: https://www.sqlite.org/lang_createtable.html). Added `testCreateTableWithForeignKey` test.

#### addForeignKey
Fixed two issues in `addForeignKey()`. The `INSERT INTO ... SELECT` query did not contain any column information, resulting in an error when PDO error mode was set to exception/error. This was due to an always empty `$columns` array. This is fixed by assigning the `pragma table_info` result to `$rows` and using it to build the `$columns` array. The table names in the `INSERT INTO ... SELECT ` query are now quotes to prevent issues when using reserved words. Added `testAddForeignKeyWithPdoExceptionErrorMode` test.
