### PR TITLE
Add `wrapper` option to environment

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -84,6 +84,10 @@ EOT
             $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
         }
 
+        if (isset($envOptions['wrapper'])) {
+            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper']);
+        }
+
         if (isset($envOptions['name'])) {
             $output->writeln('<info>using database</info> ' . $envOptions['name']);
         }

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -84,6 +84,10 @@ EOT
             $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
         }
 
+        if (isset($envOptions['wrapper'])) {
+            $output->writeln('<info>using wrapper</info> ' . $envOptions['wrapper']);
+        }
+
         if (isset($envOptions['name'])) {
             $output->writeln('<info>using database</info> ' . $envOptions['name']);
         }

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -270,6 +270,11 @@ class Environment
         $adapter = AdapterFactory::instance()
             ->getAdapter($this->options['adapter'], $this->options);
 
+        if (isset($this->options['wrapper'])) {
+            $adapter = AdapterFactory::instance()
+                ->getWrapper($this->options['wrapper'], $adapter);
+        }
+
         if ($this->getOutput()) {
             $adapter->setOutput($this->getOutput());
         }

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -23,6 +23,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 'default_database' => 'testing',
                 'testing' => array(
                     'adapter' => 'sqllite',
+                    'wrapper' => 'testwrapper',
                     'path' => '%%PHINX_CONFIG_PATH%%/testdb/test.db'
                 ),
                 'production' => array(

--- a/tests/Phinx/Config/_files/valid_config.php
+++ b/tests/Phinx/Config/_files/valid_config.php
@@ -8,6 +8,7 @@ return array(
         'default_database' => 'dev',
         'dev' => array(
             'adapter' => 'mysql',
+            'wrapper' => 'testwrapper',
             'host' => 'localhost',
             'name' => 'testing',
             'user' => 'root',


### PR DESCRIPTION
This pull requests adds a `wrapper` option to the environment configuration. An example use case is to change the defaults when creating a new table by using unsigned primary keys and a particular collation.

If you use a php configuration file and register your adapter wrapper there, it works without any other changes. Here is a sample configuration:

```php
<?php
use Phinx\Db\Adapter\AdapterFactory;
require_once 'path/to/TestAdapterWrapper.php';
AdapterFactory::instance()->registerWrapper('testwrapper', 'Svenax\Content\Phinx\Db\Adapter\TestAdapterWrapper');

return array(
    'paths' => array(
        'migrations' => '%%PHINX_CONFIG_DIR%%/migrations'
    ),
    'environments' => array(
        'default_migration_table' => 'phinxlog',
        'default_database' => 'development',
        'development' => array(
            'adapter' => 'mysql',
            'wrapper' => 'testwrapper',
            'host' => 'localhost',
            'name' => 'development_db',
            'user' => 'root',
            'pass' => '',
            'port' => 3306
        )
    )
);
```

And here is an example wrapper class:

```php
<?php
namespace Svenax\Content\Phinx\Db\Adapter;

use Phinx\Db\Adapter\AdapterWrapper;
use Phinx\Db\Table;
use Phinx\Db\Table\Column;

class TestAdapterWrapper extends AdapterWrapper
{
    public function getAdapterType()
    {
        return $this->getOption('adapter');
    }

    public function createTable(Table $table)
    {
        $options = $table->getOptions();
        $options['collation'] = 'utf8mb4_unicode_ci';
        $id = isset($options['id']) ? $options['id'] : true;

        if ($id !== false) {
            if ($id === true) $id = 'id';

            $columns = $table->getPendingColumns();
            $column = new Column();
            $column->setName($id)
                   ->setType('integer')
                   ->setSigned(false)
                   ->setIdentity(true);
            array_unshift($columns, $column);
            $table->setPendingColumns($columns);

            $options['primary_key'] = $id;
            $options['id'] = false; // So the parent doesn't recreate the column
            $table->setOptions($options);
        }

        parent::createTable($table);
    }
}
```