### PR TITLE
Fixed change comment block

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -40,9 +40,11 @@ and a commented out one:
              * http://docs.phinx.org/en/latest/migrations.html#the-change-method
              *
              * Uncomment this method if you would like to use it.
-             *
+             */
+            /*
             public function change()
             {
+             
             }
             */
 


### PR DESCRIPTION
Improves the ability to uncomment the block in one hit.  Also makes the markdown render the commented block correctly (removing the red highlighting)