### PR TITLE
Throw RuntimeException when default CURRENT_TIMESTAMP on DATETIME field not supported

### DIFF
--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -790,13 +790,13 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
     public function testGetDefaultValueDefinitionCurrentTimestampException()
     {
         $this->setExpectedException('\RuntimeException', 'You cannot use CURRENT_TIMESTAMP as DEFAULT value for DATETIME on this version (5.6.4) of MySQL.');
-        $this->assertFetchRowSql("SHOW VARIABLES where variable_name like 'version';", ['Value' => '5.6.4']);
+        $this->assertFetchRowSql("SHOW VARIABLES where variable_name like 'version';",  array('Value' => '5.6.4'));
         $this->adapter->getDefaultValueDefinition('CURRENT_TIMESTAMP', 'DATETIME');
     }
 
     public function testGetDefaultValueDefinitionCurrentTimestampCorrectVersion()
     {
-        $this->assertFetchRowSql("SHOW VARIABLES where variable_name like 'version';", ['Value' => '5.6.5']);
+        $this->assertFetchRowSql("SHOW VARIABLES where variable_name like 'version';", array('Value' => '5.6.5'));
         $this->assertEquals(' DEFAULT CURRENT_TIMESTAMP',
             $this->adapter->getDefaultValueDefinition('CURRENT_TIMESTAMP', 'DATETIME'));
     }


### PR DESCRIPTION
Ran into this issue: https://github.com/robmorgan/phinx/issues/261

This PR simply creates a little more visibility to the problem which otherwise isn't very obvious. 

If the version of MySQL is too low to support a CURRENT_TIMESTAMP DEFAULT on a DATETIME column, throw an Exception to give some visibility to the user. 





