### PR TITLE
Fixed: When the column option 'scale' was ZERO, it would use 'limit' …

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -962,7 +962,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
 
         $def = '';
         $def .= strtoupper($sqlType['name']);
-        if ($column->getPrecision() && $column->getScale()) {
+        if ($column->getPrecision() && $column->getScale() !== null) {
             $def .= '(' . $column->getPrecision() . ',' . $column->getScale() . ')';
         } elseif (isset($sqlType['limit'])) {
             $def .= '(' . $sqlType['limit'] . ')';


### PR DESCRIPTION
…instead of 'precision' to create the SQL.

The code:

    $table->addColumn('max_amount', 'decimal', [
            'default' => null,
            'precision' => 50,
            'scale' => 0,
            'null' => false,
            'after' => 'min_amount',
        ]);

was creating a `decimal(10,0)` instead of a `decimal(50,0)`. This fixes that.