### PR TITLE
Add support for BLOB sizes in MySQL (issue #45)

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -49,6 +49,13 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     const TEXT_MEDIUM  = 16777215;
     const TEXT_LONG    = 4294967295;
 
+    // According to https://dev.mysql.com/doc/refman/5.0/en/blob.html BLOB sizes are the same as TEXT
+    const BLOB_TINY    = 255;
+    const BLOB_SMALL   = 255; /* deprecated, alias of BLOB_TINY */
+    const BLOB_REGULAR = 65535;
+    const BLOB_MEDIUM  = 16777215;
+    const BLOB_LONG    = 4294967295;
+
     const INT_TINY    = 255;
     const INT_SMALL   = 65535;
     const INT_MEDIUM  = 16777215;
@@ -734,6 +741,23 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 }
                 return array('name' => 'text');
                 break;
+            case static::PHINX_TYPE_BINARY:
+                if ($limit) {
+                    $sizes = array(
+                        // Order matters! Size must always be tested from longest to shortest!
+                        'longblob'   => static::BLOB_LONG,
+                        'mediumblob' => static::BLOB_MEDIUM,
+                        'blob'       => static::BLOB_REGULAR,
+                        'tinyblob'   => static::BLOB_SMALL,
+                    );
+                    foreach ($sizes as $name => $length) {
+                        if ($limit >= $length) {
+                            return array('name' => $name);
+                        }
+                    }
+                }
+                return array('name' => 'blob');
+                break;
             case static::PHINX_TYPE_INTEGER:
                 if ($limit && $limit >= static::INT_TINY) {
                     $sizes = array(
@@ -782,9 +806,6 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 break;
             case static::PHINX_TYPE_DATE:
                 return array('name' => 'date');
-                break;
-            case static::PHINX_TYPE_BINARY:
-                return array('name' => 'blob');
                 break;
             case static::PHINX_TYPE_BOOLEAN:
                 return array('name' => 'tinyint', 'limit' => 1);
@@ -876,6 +897,18 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                     break;
                 case 'blob':
                     $type = static::PHINX_TYPE_BINARY;
+                    break;
+                case 'tinyblob':
+                    $type  = static::PHINX_TYPE_BINARY;
+                    $limit = static::BLOB_TINY;
+                    break;
+                case 'mediumblob':
+                    $type  = static::PHINX_TYPE_BINARY;
+                    $limit = static::BLOB_MEDIUM;
+                    break;
+                case 'longblob':
+                    $type  = static::PHINX_TYPE_BINARY;
+                    $limit = static::BLOB_LONG;
                     break;
                 case 'tinytext':
                     $type  = static::PHINX_TYPE_TEXT;

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -823,6 +823,26 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('name' => 'longtext'),
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_TEXT, MysqlAdapter::TEXT_LONG+1));
 
+        //blob combinations
+        $this->assertEquals(array('name' => 'blob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY));
+        $this->assertEquals(array('name' => 'tinyblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_TINY));
+        $this->assertEquals(array('name' => 'tinyblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_TINY+1));
+        $this->assertEquals(array('name' => 'blob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_REGULAR));
+        $this->assertEquals(array('name' => 'blob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_REGULAR+1));
+        $this->assertEquals(array('name' => 'mediumblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_MEDIUM));
+        $this->assertEquals(array('name' => 'mediumblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_MEDIUM+1));
+        $this->assertEquals(array('name' => 'longblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_LONG));
+        $this->assertEquals(array('name' => 'longblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_LONG+1));
+
         //int combinations
         $this->assertEquals(array('name' => 'int', 'limit' => 11),
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_INTEGER));
@@ -923,6 +943,14 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                             $this->adapter->getPhinxType('mediumtext'));
         $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_TEXT, 'limit' => MysqlAdapter::TEXT_LONG, 'precision' => null),
                             $this->adapter->getPhinxType('longtext'));
+        $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_BINARY, 'limit' => MysqlAdapter::BLOB_TINY, 'precision' => null),
+                            $this->adapter->getPhinxType('tinyblob'));
+        $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_BINARY, 'limit' => null, 'precision' => null),
+                            $this->adapter->getPhinxType('blob'));
+        $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_BINARY, 'limit' => MysqlAdapter::BLOB_MEDIUM, 'precision' => null),
+                            $this->adapter->getPhinxType('mediumblob'));
+        $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_BINARY, 'limit' => MysqlAdapter::BLOB_LONG, 'precision' => null),
+                            $this->adapter->getPhinxType('longblob'));
         $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_POINT, 'limit' => null, 'precision' => null),
                             $this->adapter->getPhinxType('point'));
         $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_GEOMETRY, 'limit' => null, 'precision' => null),


### PR DESCRIPTION
This pull requests adds support for:

* TINYBLOB
* MEDIUMBLOB
* LONGBLOB

Mostly, using copy paste of the existing TEXT field sizes.