### PR TITLE
simplify check for PostgresAdapter::hasTable

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -161,7 +161,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             )
         );
 
-        return $result->rowCount() !== 0;
+        return $result->rowCount() === 1;
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -151,10 +151,8 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
     public function hasTable($tableName)
     {
         $tables = array();
-        $rows = $this->fetchAll(sprintf('SELECT table_name FROM information_schema.tables WHERE table_schema = \'%s\';', $this->getSchemaName()));
-        foreach ($rows as $row) {
-            $tables[] = strtolower($row[0]);
-        }
+        $result = $this->getConnection()->query(sprintf('SELECT lower(table_name) FROM information_schema.tables WHERE table_schema = \'%s\';', $this->getSchemaName()));
+        while ($tables[] = $result->fetchColumn());
         return in_array(strtolower($tableName), $tables);
     }
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -150,10 +150,18 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     public function hasTable($tableName)
     {
-        $tables = array();
-        $result = $this->getConnection()->query(sprintf('SELECT lower(table_name) FROM information_schema.tables WHERE table_schema = \'%s\';', $this->getSchemaName()));
-        while ($tables[] = $result->fetchColumn());
-        return in_array(strtolower($tableName), $tables);
+        $result = $this->getConnection()->query(
+            sprintf(
+                'SELECT *
+                FROM information_schema.tables
+                WHERE table_schema = %s
+                AND lower(table_name) = lower(%s)',
+                $this->getConnection()->quote($this->getSchemaName()),
+                $this->getConnection()->quote($tableName)
+            )
+        );
+
+        return $result->rowCount() !== 0;
     }
 
     /**


### PR DESCRIPTION
Trying to use my own connection, i've got `Notice: Undefined offset: 0` because i'm using `PDO::FETCH_ASSOC` which doesn't return numeric indexes for its result.

Since we're only interested in one column anyway, we could change it to `PDOStatement::fetchColumn` which would work regardless of the underlying connection and its options.