### PR TITLE
Looser contraint for Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     }],
     "require": {
         "php": ">=5.3.2",
-        "symfony/console": "~2.6.0",
-        "symfony/config": "~2.6.0",
-        "symfony/yaml": "~2.6.0"
+        "symfony/console": "~2.6",
+        "symfony/config": "~2.6",
+        "symfony/yaml": "~2.6"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
Symfony 2.7 has been released and is backward compatible with Symfony 2.6.
Currently the version constraints in composer.json is ~2.6.0, which translates to >=2.6.0,<2.7.
I've made the constraint looser with ~2.6, which translates to >=2.6.0,<3.0

See issue #561