### PR TITLE
Migration file format definition moved to Util for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ phpunit.xml
 
 # sqlite test database
 phinx_testing.sqlite3
+phinx_testing.sqlite3-journal
+

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -376,13 +376,7 @@ class Manager
                     }
 
                     // convert the filename to a class name
-                    $class = preg_replace('/^[0-9]+_/', '', basename($filePath));
-                    $class = str_replace('_', ' ', $class);
-                    $class = ucwords($class);
-                    $class = str_replace(' ', '', $class);
-                    if (false !== strpos($class, '.')) {
-                        $class = substr($class, 0, strpos($class, '.'));
-                    }
+                    $class = Util::mapFileNameToClassName(basename($filePath));
 
                     if (isset($fileNames[$class])) {
                         throw new \InvalidArgumentException(sprintf(

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -369,9 +369,7 @@ class Manager
 
             foreach ($phpFiles as $filePath) {
                 if (Util::isValidMigrationFilePath($filePath)) {
-                    $matches = array();
-                    preg_match('/^[0-9]+/', basename($filePath), $matches); // get the version from the start of the filename
-                    $version = $matches[0];
+                    $version = Util::getVersionFromMigrationFilePath($filePath);
 
                     if (isset($versions[$version])) {
                         throw new \InvalidArgumentException(sprintf('Duplicate migration - "%s" has the same version as "%s"', $filePath, $versions[$version]->getVersion()));

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -30,6 +30,7 @@ namespace Phinx\Migration;
 
 use Symfony\Component\Console\Output\OutputInterface;
 use Phinx\Config\ConfigInterface;
+use Phinx\Migration\Util;
 use Phinx\Migration\Manager\Environment;
 
 class Manager
@@ -367,7 +368,7 @@ class Manager
             $versions = array();
 
             foreach ($phpFiles as $filePath) {
-                if (preg_match('/([0-9]+)_([_a-z0-9]*).php/', basename($filePath))) {
+                if (Util::isValidMigrationFilePath($filePath)) {
                     $matches = array();
                     preg_match('/^[0-9]+/', basename($filePath), $matches); // get the version from the start of the filename
                     $version = $matches[0];

--- a/src/Phinx/Migration/Util.php
+++ b/src/Phinx/Migration/Util.php
@@ -63,6 +63,18 @@ class Util
     }
 
     /**
+     *
+     * Migration file names must be in a format similar to following:
+     * $timestamp_$lowerCaseMigrationName
+     *
+     * @see Util::mapClassNameToFileName()
+     * @param string $filePath Path to the migration file to be checked
+     */
+    public static function isValidMigrationFilePath($filePath){
+        return preg_match('/([0-9]+)_([_a-z0-9]*).php/', basename($filePath));
+    }
+
+    /**
      * Check if a migration class name is valid.
      *
      * Migration class names must be in CamelCase format.

--- a/src/Phinx/Migration/Util.php
+++ b/src/Phinx/Migration/Util.php
@@ -63,15 +63,29 @@ class Util
     }
 
     /**
+     * Check if the given path to a migration file is valid.
      *
      * Migration file names must be in a format similar to following:
      * $timestamp_$lowerCaseMigrationName
      *
      * @see Util::mapClassNameToFileName()
      * @param string $filePath Path to the migration file to be checked
+     * @return boolean true if and only if $filePath is a valid path to a migration file
      */
     public static function isValidMigrationFilePath($filePath){
         return preg_match('/([0-9]+)_([_a-z0-9]*).php/', basename($filePath));
+    }
+
+    /**
+     * Returns the version of a migration based on the path to the file of the migration
+     *
+     * @param string $filePath Path to the migration file the version number is to be acquired
+     * @return string version of the migration corresponding to the given file path
+     */
+    public static function getVersionFromMigrationFilePath($filePath){
+        $matches = array();
+        preg_match('/^[0-9]+/', basename($filePath), $matches); // get the version from the start of the filename
+        return $matches[0];
     }
 
     /**

--- a/src/Phinx/Migration/Util.php
+++ b/src/Phinx/Migration/Util.php
@@ -63,6 +63,24 @@ class Util
     }
 
     /**
+     * Turn migration file names like '20150601153656_create_user_table.php' into class names like 'CreateUserTable'.
+     *
+     * @param string $className Class Name
+     * @return string
+     */
+    public static function mapFileNameToClassName($fileName)
+    {
+        $class = preg_replace('/^[0-9]+_/', '', $fileName);
+        $class = str_replace('_', ' ', $class);
+        $class = ucwords($class);
+        $class = str_replace(' ', '', $class);
+        if (false !== strpos($class, '.')) {
+            $class = substr($class, 0, strpos($class, '.'));
+        }
+        return $class;
+    }
+
+    /**
      * Check if the given path to a migration file is valid.
      *
      * Migration file names must be in a format similar to following:

--- a/tests/Phinx/Migration/UtilTest.php
+++ b/tests/Phinx/Migration/UtilTest.php
@@ -25,11 +25,45 @@ class UtilTest extends \PHPUnit_Framework_TestCase
         $expectedResults = array(
             'CamelCase87afterSomeBooze'   => '/^\d{14}_camel_case87after_some_booze\.php$/',
             'CreateUserTable'             => '/^\d{14}_create_user_table\.php$/',
-            'LimitResourceNamesTo30Chars' => '/^\d{14}_limit_resource_names_to30_chars\.php$/',
+            'LimitResourceNamesTo30Chars' => '/^\d{14}_limit_resource_names_to30_chars\.php$/'
         );
 
         foreach ($expectedResults as $input => $expectedResult) {
             $this->assertRegExp($expectedResult, Util::mapClassNameToFileName($input));
+        }
+    }
+
+    public function testMapFileNameToClassName()
+    {
+        $expectedResults = array(
+            '20150601153940_camel_case87after_some_booze.php' => '/^CamelCase87afterSomeBooze$/'
+        );
+
+        foreach ($expectedResults as $input => $expectedResult) {
+            $this->assertRegExp($expectedResult, Util::mapFileNameToClassName($input));
+        }
+    }
+
+    public function testIsValidMigrationFilePath(){
+        $expectedResults = array(
+            '/some/path/20150601153656_create_user_table.php'         => true,
+            '/some/Other Path/20150601153656_another_migration.php'   => true,
+            '/some/ugly/path/20150601153656_das_ist_unschön.php'   => false
+        );
+
+
+        foreach ($expectedResults as $input => $expectedResult) {
+            $this->assertEquals($expectedResult, Util::isValidMigrationFilePath($input));
+        }
+    }
+
+    public function testGetVersionFromMigrationFilePath(){
+        $expectedResults = array(
+            '20150601153940_some_migration.php' => '/^20150601153940$/'
+        );
+
+        foreach ($expectedResults as $input => $expectedResult) {
+            $this->assertRegExp($expectedResult, Util::getVersionFromMigrationFilePath($input));
         }
     }
 
@@ -39,7 +73,8 @@ class UtilTest extends \PHPUnit_Framework_TestCase
             'CAmelCase'         => false,
             'CreateUserTable'   => true,
             'Test'              => true,
-            'test'              => false
+            'test'              => false,
+            'Häßlich'         => false
         );
 
         foreach ($expectedResults as $input => $expectedResult) {


### PR DESCRIPTION
Moved migration file format definitions from Manager::getMigrations() toUtil.php and implemented unit tests accordingly.
Added sqlite3-journal files to .gitignore