### PR TITLE
Add explanation in regards to the UTF8 charset for SQL Server

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -157,7 +157,7 @@ Declaring an SQLite database uses a simplified structure:
 
 When using the ``sqlsrv`` adapter and connecting to a named instance of 
 SQLServer you should omit the ``port`` setting as sqlsrv will negotiate the port
-automatically.
+automatically. Additionally, omit the ``charset: utf8`` or change to ``charset: 65001`` which corresponds to UTF8 for SQL Server.
 
 You can provide a custom adapter by registering an implementation of the `Phinx\\Db\\Adapter\\AdapterInterface`
 with `AdapterFactory`: 


### PR DESCRIPTION
When using charset: utf8 as proposed in the documentation (which works for mysql), SQL Server fails with SQLSTATE[IMSSP]: An invalid encoding was specified for SQLSRV_ATTR_ENCODING.