### PR TITLE
Add function for soft deleting table column

### DIFF
--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -558,13 +558,13 @@ class Table
     public function addTimestamps($softDelete = false)
     {
         $this->addColumn('created_at', 'timestamp', array(
-                'default' => 'CURRENT_TIMESTAMP',
-                'update' => ''
-            ))
-             ->addColumn('updated_at', 'timestamp', array(
+            'default' => 'CURRENT_TIMESTAMP',
+            'update'  => ''
+        ))
+            ->addColumn('updated_at', 'timestamp', array(
                 'null'    => true,
                 'default' => null
-             ));
+            ));
 
         if ($softDelete) {
             $this->addSoftDelete();

--- a/src/Phinx/Db/Table.php
+++ b/src/Phinx/Db/Table.php
@@ -550,11 +550,12 @@ class Table
     }
 
     /**
-     * Add timestamp columns created_at and updated_at to the table.
+     * Add timestamp columns created_at and updated_at to the table, along with an optional soft delete column
      *
+     * @param bool $softDelete Include soft delete column
      * @return Table
      */
-    public function addTimestamps()
+    public function addTimestamps($softDelete = false)
     {
         $this->addColumn('created_at', 'timestamp', array(
                 'default' => 'CURRENT_TIMESTAMP',
@@ -564,6 +565,25 @@ class Table
                 'null'    => true,
                 'default' => null
              ));
+
+        if ($softDelete) {
+            $this->addSoftDelete();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a soft delete timestamp column deleted_at to the table
+     *
+     * @return Table
+     */
+    public function addSoftDelete()
+    {
+        $this->addColumn('deleted_at', 'timestamp', array(
+            'null' => true,
+            'default' => null
+        ));
 
         return $this;
     }

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -200,6 +200,50 @@ class TableTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($columns[1]->getDefault());
     }
 
+    public function testAddSoftDelete()
+    {
+        $adapter = new MysqlAdapter(array());
+
+        $table = new \Phinx\Db\Table('ntable', array(), $adapter);
+        $table->addSoftDelete();
+
+        $columns = $table->getPendingColumns();
+
+        $this->assertEquals('deleted_at', $columns[0]->getName());
+        $this->assertEquals('timestamp', $columns[0]->getType());
+        $this->assertNull($columns[0]->getDefault());
+        $this->assertEquals('', $columns[0]->getUpdate());
+    }
+
+    public function testAddTimestampsWithSoftDelete()
+    {
+        $adapter = new MysqlAdapter(array());
+        $table = new \Phinx\Db\Table('ntable', array(), $adapter);
+        $table->addTimestamps(true);
+
+        $columns = $table->getPendingColumns();
+
+        $this->assertCount(3, $columns);
+
+        // created_at
+        $this->assertEquals('created_at', $columns[0]->getName());
+        $this->assertEquals('timestamp', $columns[0]->getType());
+        $this->assertEquals('CURRENT_TIMESTAMP', $columns[0]->getDefault());
+        $this->assertEquals('', $columns[0]->getUpdate());
+
+        // updated_at
+        $this->assertEquals('updated_at', $columns[1]->getName());
+        $this->assertEquals('timestamp', $columns[1]->getType());
+        $this->assertTrue($columns[1]->isNull());
+        $this->assertNull($columns[1]->getDefault());
+
+        // deleted_at
+        $this->assertEquals('deleted_at', $columns[2]->getName());
+        $this->assertEquals('timestamp', $columns[2]->getType());
+        $this->assertNull($columns[2]->getDefault());
+        $this->assertEquals('', $columns[2]->getUpdate());
+    }
+
     public function testInsert()
     {
         $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', array(), array(array()));


### PR DESCRIPTION
Adds the ability to add a `deleted_at` column to a table using either of two methods:

- As a function on the table

```php
$table->addSoftDelete()
```

- As an argument in the `addTimestamps()` function

```php
$table->addTimestamps(true)
```