### PR TITLE
Documentation improvements for valid column types

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -417,7 +417,7 @@ Column types are specified as strings and can be one of:
 
 In addition, the MySQL adapter supports ``enum`` and ``set`` column types.
 
-In addition, the Postgres adapter supports ``json`` column types
+In addition, the Postgres adapter supports ``json`` and ``jsonb`` column types
 (PostgreSQL 9.3 and above).
 
 For valid options, see the `Valid Column Options`_ below.

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -413,10 +413,11 @@ Column types are specified as strings and can be one of:
 -  date
 -  binary
 -  boolean
+-  uuid
 
 In addition, the MySQL adapter supports ``enum`` and ``set`` column types.
 
-In addition, the Postgres adapter supports ``json`` and ``uuid`` column types
+In addition, the Postgres adapter supports ``json`` column types
 (PostgreSQL 9.3 and above).
 
 For valid options, see the `Valid Column Options`_ below.

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -401,18 +401,18 @@ Valid Column Types
 
 Column types are specified as strings and can be one of:
 
--  string
--  text
--  integer
 -  biginteger
--  float
--  decimal
--  datetime
--  timestamp
--  time
--  date
 -  binary
 -  boolean
+-  date
+-  datetime
+-  decimal
+-  float
+-  integer
+-  string
+-  text
+-  time
+-  timestamp
 -  uuid
 
 In addition, the MySQL adapter supports ``enum`` and ``set`` column types.

--- a/docs/seeding.rst
+++ b/docs/seeding.rst
@@ -437,22 +437,23 @@ Valid Column Types
 
 Column types are specified as strings and can be one of:
 
--  string
--  text
--  integer
 -  biginteger
--  float
--  decimal
--  datetime
--  timestamp
--  time
--  date
 -  binary
 -  boolean
+-  date
+-  datetime
+-  decimal
+-  float
+-  integer
+-  string
+-  text
+-  time
+-  timestamp
+-  uuid
 
 In addition, the MySQL adapter supports ``enum`` and ``set`` column types.
 
-In addition, the Postgres adapter supports ``json`` and ``uuid`` column types
+In addition, the Postgres adapter supports ``json`` and ``jsonb`` column types
 (PostgreSQL 9.3 and above).
 
 For valid options, see the `Valid Column Options`_ below.


### PR DESCRIPTION
* Added ```uuid``` to the list of columns
* Added ```jsonb``` to Postgres
* Sorted column types alphabetically