### PR TITLE
remove Bad Apostrophe from migrations.rst

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -628,7 +628,7 @@ To rename a column access an instance of the Table object then call the
 Adding a Column After Another Column
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When adding a column you can dictate it's position using the ``after`` option.
+When adding a column you can dictate its position using the ``after`` option.
 
 .. code-block:: php
 


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!