### PR TITLE
allow setting template file or class in the config file. this time with feeling.

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -243,6 +243,34 @@ class Config implements ConfigInterface
     }
 
     /**
+     * Get the template file name.
+     *
+     * @return string|false
+     */
+     public function getTemplateFile()
+     {
+        if (!isset($this->values['templates']['file'])) {
+            return false;
+        }
+
+        return $this->values['templates']['file'];
+     }
+
+    /**
+     * Get the template class name.
+     *
+     * @return string|false
+     */
+     public function getTemplateClass()
+     {
+        if (!isset($this->values['templates']['class'])) {
+            return false;
+        }
+
+        return $this->values['templates']['class'];
+     }
+
+    /**
      * Replace tokens in the specified array.
      *
      * @param array $arr Array to replace

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -93,4 +93,19 @@ interface ConfigInterface extends \ArrayAccess
      * @return string
      */
     public function getMigrationPath();
+
+     /**
+     * Get the template file name.
+     *
+     * @return string|false
+     */
+     public function getTemplateFile();
+
+     /**
+     * Get the template class name.
+     *
+     * @return string|false
+     */
+     public function getTemplateClass();
+
 }

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -127,8 +127,16 @@ class Create extends AbstractCommand
         }
 
         // Get the alternative template and static class options, but only allow one of them.
-        $altTemplate = $input->getOption('template');
-        $creationClassName = $input->getOption('class');
+        $altTemplate = $this->getConfig()->getTemplateFile();
+        if (!$altTemplate) {
+            $altTemplate = $input->getOption('template');
+        }
+
+        $creationClassName = $this->getConfig()->getTemplateClass();
+        if (!$creationClassName) {
+            $creationClassName = $input->getOption('class');
+        }
+
         if ($altTemplate && $creationClassName) {
             throw new \InvalidArgumentException('Cannot use --template and --class at the same time');
         }

--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -127,14 +127,14 @@ class Create extends AbstractCommand
         }
 
         // Get the alternative template and static class options, but only allow one of them.
-        $altTemplate = $this->getConfig()->getTemplateFile();
+        $altTemplate = $input->getOption('template');
         if (!$altTemplate) {
-            $altTemplate = $input->getOption('template');
+            $altTemplate = $this->getConfig()->getTemplateFile();
         }
 
-        $creationClassName = $this->getConfig()->getTemplateClass();
+        $creationClassName = $input->getOption('class');
         if (!$creationClassName) {
-            $creationClassName = $input->getOption('class');
+            $creationClassName = $this->getConfig()->getTemplateClass();
         }
 
         if ($altTemplate && $creationClassName) {

--- a/tests/Phinx/Config/AbstractConfigTest.php
+++ b/tests/Phinx/Config/AbstractConfigTest.php
@@ -32,6 +32,10 @@ abstract class AbstractConfigTest extends \PHPUnit_Framework_TestCase
             'paths' => array(
                 'migrations' => $this->getMigrationPath(),
             ),
+            'templates' => array(
+                'file' => '%%PHINX_CONFIG_PATH%%/tpl/testtemplate.txt',
+                'class' => '%%PHINX_CONFIG_PATH%%/tpl/testtemplate.php'
+            ),
             'environments' => array(
                 'default_migration_table' => 'phinxlog',
                 'default_database' => 'testing',

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -156,4 +156,15 @@ class ConfigTest extends AbstractConfigTest
         $config = new Config(array('migration_base_class' => 'Phinx\Migration\AlternativeAbstractMigration'));
         $this->assertEquals('Phinx\Migration\AlternativeAbstractMigration', $config->getMigrationBaseClassName(false));
     }
+
+    /**
+     * @covers \Phinx\Config\Config::getTemplateFile();
+     * @covers \Phinx\Config\Config::getTemplateClass();
+     */
+    public function testGetTemplateValuesFalseOnEmpty()
+    {
+        $config = new \Phinx\Config\Config(array());
+        $this->assertFalse($config->getTemplateFile());
+        $this->assertFalse($config->getTemplateClass());
+    }
 }


### PR DESCRIPTION
these updates allow you to define templates and classes in the config file instead of having to use --template and --class all the time from the command line. the same rules about not using both at the same time apply. using --class or --template from the cli will overrule the config file.

    templates:
        file: path/to/file
        class: f\q\c\n