### PR TITLE
all migrations now run inside a single transaction

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -223,29 +223,46 @@ class Manager
         // are we migrating up or down?
         $direction = $version > $current ? MigrationInterface::UP : MigrationInterface::DOWN;
 
-        if ($direction == MigrationInterface::DOWN) {
-            // run downs first
-            krsort($migrations);
+        $adapter = $this->getEnvironment($environment)->getAdapter();
+        if ($adapter->hasTransactions()) {
+            $adapter->beginTransaction();
+        }
+
+        try {
+            if ($direction == MigrationInterface::DOWN) {
+                // run downs first
+                krsort($migrations);
+                foreach ($migrations as $migration) {
+                    if ($migration->getVersion() <= $version) {
+                        break;
+                    }
+
+                    if (in_array($migration->getVersion(), $versions)) {
+                        $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                    }
+                }
+            }
+
+            ksort($migrations);
             foreach ($migrations as $migration) {
-                if ($migration->getVersion() <= $version) {
+                if ($migration->getVersion() > $version) {
                     break;
                 }
 
-                if (in_array($migration->getVersion(), $versions)) {
-                    $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                if (!in_array($migration->getVersion(), $versions)) {
+                    $this->executeMigration($environment, $migration, MigrationInterface::UP);
                 }
             }
+        } catch (\Exception $e) {
+           if ($adapter->hasTransactions()) {
+               $adapter->rollbackTransaction();
+               $this->output->writeln('<info>Exception occured - rolling back migrate command.</info>');
+           }
+           throw $e;
         }
 
-        ksort($migrations);
-        foreach ($migrations as $migration) {
-            if ($migration->getVersion() > $version) {
-                break;
-            }
-
-            if (!in_array($migration->getVersion(), $versions)) {
-                $this->executeMigration($environment, $migration, MigrationInterface::UP);
-            }
+        if ($adapter->hasTransactions()) {
+            $adapter->commitTransaction();
         }
     }
 
@@ -322,16 +339,33 @@ class Manager
             return;
         }
 
-        // Revert the migration(s)
-        krsort($migrations);
-        foreach ($migrations as $migration) {
-            if ($migration->getVersion() <= $version) {
-                break;
-            }
+        $adapter = $this->getEnvironment($environment)->getAdapter();
+        if ($adapter->hasTransactions()) {
+            $adapter->beginTransaction();
+        }
 
-            if (in_array($migration->getVersion(), $versions)) {
-                $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+        try {
+            // Revert the migration(s)
+            krsort($migrations);
+            foreach ($migrations as $migration) {
+                if ($migration->getVersion() <= $version) {
+                    break;
+                }
+
+                if (in_array($migration->getVersion(), $versions)) {
+                    $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                }
             }
+        } catch (\Exception $e) {
+            if ($adapter->hasTransactions()) {
+                $adapter->rollbackTransaction();
+                $this->output->writeln('<info>Exception occured - rolling back rollback command.</info>');
+            }
+            throw $e;
+        }
+
+        if ($adapter->hasTransactions()) {
+            $adapter->commitTransaction();
         }
     }
 

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -91,11 +91,6 @@ class Environment
         $direction = ($direction == MigrationInterface::UP) ? MigrationInterface::UP : MigrationInterface::DOWN;
         $migration->setAdapter($this->getAdapter());
 
-        // begin the transaction if the adapter supports it
-        if ($this->getAdapter()->hasTransactions()) {
-            $this->getAdapter()->beginTransaction();
-        }
-
         // Run the migration
         if (method_exists($migration, MigrationInterface::CHANGE)) {
             if ($direction == MigrationInterface::DOWN) {
@@ -114,11 +109,6 @@ class Environment
             }
         } else {
             $migration->{$direction}();
-        }
-
-        // commit the transaction if the adapter supports it
-        if ($this->getAdapter()->hasTransactions()) {
-            $this->getAdapter()->commitTransaction();
         }
 
         // Record it in the database

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -152,30 +152,6 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->environment->executeMigration($downMigration, MigrationInterface::DOWN);
     }
 
-    public function testExecutingAMigrationWithTransactions()
-    {
-        // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
-        $adapterStub->expects($this->once())
-                    ->method('beginTransaction');
-
-        $adapterStub->expects($this->once())
-                    ->method('commitTransaction');
-
-        $adapterStub->expects($this->exactly(2))
-                    ->method('hasTransactions')
-                    ->will($this->returnValue(true));
-
-        $this->environment->setAdapter($adapterStub);
-
-        // migrate
-        $migration = $this->getMock('\Phinx\Migration\AbstractMigration', array('up'), array('20110301080000'));
-        $migration->expects($this->once())
-                  ->method('up');
-
-        $this->environment->executeMigration($migration, MigrationInterface::UP);
-    }
-
     public function testExecutingAChangeMigrationUp()
     {
         // stub adapter

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -177,11 +177,20 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testMigrationsByDate($availableMigrations, $dateString, $expectedMigration)
     {
+        // stub adapter
+        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub->expects($this->any())
+                    ->method('hasTransaction')
+                    ->will($this->returnValue(true));
+
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->once())
                 ->method('getVersions')
                 ->will($this->returnValue($availableMigrations));
+        $envStub->expects($this->any())
+                ->method('getAdapter')
+                ->will($this->returnValue($adapterStub));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->migrateToDateTime('mockenv', new \DateTime($dateString));
@@ -202,11 +211,20 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testRollbacksByDate($availableRollbacks, $dateString, $expectedRollback)
     {
+        // stub adapter
+        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub->expects($this->any())
+                    ->method('hasTransaction')
+                    ->will($this->returnValue(true));
+
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->any())
                 ->method('getVersions')
                 ->will($this->returnValue($availableRollbacks));
+        $envStub->expects($this->any())
+                ->method('getAdapter')
+                ->will($this->returnValue($adapterStub));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollbackToDateTime('mockenv', new \DateTime($dateString));
@@ -217,6 +235,132 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         } else {
             $this->assertContains($expectedRollback, $output);
         }
+    }
+
+    /**
+     * Test that whole migrate method runs inside a transaction
+     */
+    public function testMigrationsTransaction()
+    {
+        // stub adapter
+        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub->expects($this->any())
+                    ->method('hasTransactions')
+                    ->will($this->returnValue(true));
+        $adapterStub->expects($this->once())
+                    ->method('beginTransaction');
+        $adapterStub->expects($this->once())
+                    ->method('commitTransaction');
+
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->any())
+                ->method('getAdapter')
+                ->will($this->returnValue($adapterStub));
+        $envStub->expects($this->once())
+                ->method('getVersions')
+                ->will($this->returnValue(array()));
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->migrate('mockenv', null);
+    }
+
+    /**
+     * Test that the migrations transaction will be rolled back when exception occurs
+     */
+    public function testMigrationsTransactionRollback()
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'test exception'
+        );
+        // stub adapter
+        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub->expects($this->any())
+                    ->method('hasTransactions')
+                    ->will($this->returnValue(true));
+        $adapterStub->expects($this->once())
+                    ->method('beginTransaction');
+        $adapterStub->expects($this->once())
+                    ->method('rollbackTransaction');
+
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->any())
+                ->method('getAdapter')
+                ->will($this->returnValue($adapterStub));
+        $envStub->expects($this->once())
+                ->method('getVersions')
+                ->will($this->returnValue(array()));
+        $envStub->expects($this->once())
+                    ->method('executeMigration')
+                    ->will($this->throwException(new \InvalidArgumentException('test exception')));
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->migrate('mockenv', null);
+    }
+
+    /**
+     * Test that whole rollback method runs inside a transaction
+     */
+    public function testRollbackTransaction()
+    {
+        // stub adapter
+        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub->expects($this->any())
+                    ->method('hasTransactions')
+                    ->will($this->returnValue(true));
+        $adapterStub->expects($this->once())
+                    ->method('beginTransaction');
+        $adapterStub->expects($this->once())
+                    ->method('commitTransaction');
+
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->any())
+                ->method('getAdapter')
+                ->will($this->returnValue($adapterStub));
+        $envStub->expects($this->once())
+                ->method('getVersions')
+                ->will($this->returnValue(array(20120111235330)));
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->rollback('mockenv', null);
+    }
+
+    /**
+     * Test that the rollback transaction will be rolled back when exception occurs
+     */
+    public function testRollbackTransactionRollback()
+    {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'test exception'
+        );
+        // stub adapter
+        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub->expects($this->any())
+                    ->method('hasTransactions')
+                    ->will($this->returnValue(true));
+        $adapterStub->expects($this->once())
+                    ->method('beginTransaction');
+        $adapterStub->expects($this->once())
+                    ->method('rollbackTransaction');
+
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->any())
+                ->method('getAdapter')
+                ->will($this->returnValue($adapterStub));
+        $envStub->expects($this->once())
+                ->method('getVersions')
+                ->will($this->returnValue(array(20120111235330)));
+        $envStub->expects($this->once())
+                    ->method('executeMigration')
+                    ->will($this->throwException(new \InvalidArgumentException('test exception')));
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->migrate('mockenv', null);
     }
 
     /**


### PR DESCRIPTION
As was explained in robmorgan/phinx#6 all migrations should run in a single transaction - that way either all migrations finish successfully or none will.

I also fixed a rather strange behavior - previously rollback was never called even if a migration failed somewhere which could lead to some changes being commited when error happened outside of SQL query and autocommit was enabled (which is the default behavior for mysql, I don't know about other databases).