### PR TITLE
Allow Boolean Columns to Accept the Signed Option

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -924,6 +924,7 @@ Option    Description
 ========= ===========
 precision combine with ``scale`` set to set decimial accuracy
 scale     combine with ``precision`` to set decimial accuracy
+signed    enable or disable the ``unsigned`` option *(only applies to MySQL)*
 ========= ===========
 
 For ``enum`` and ``set`` columns:
@@ -951,6 +952,14 @@ Option   Description
 default  set default value (use with ``CURRENT_TIMESTAMP``)
 update   set an action to be triggered when the row is updated (use with ``CURRENT_TIMESTAMP``)
 timezone enable or disable the ``with time zone`` option for ``time`` and ``timestamp`` columns *(only applies to Postgres)*
+======== ===========
+
+For ``boolean``columns:
+
+======== ===========
+Option   Description
+======== ===========
+signed   enable or disable the ``unsigned`` option *(only applies to MySQL)*
 ======== ===========
 
 For foreign key definitions:

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -41,7 +41,7 @@ use Phinx\Db\Table\ForeignKey;
 class MysqlAdapter extends PdoAdapter implements AdapterInterface
 {
 
-    protected $signedColumnTypes = array('integer' => true, 'biginteger' => true, 'float' => true, 'decimal' => true);
+    protected $signedColumnTypes = array('integer' => true, 'biginteger' => true, 'float' => true, 'decimal' => true, 'boolean' => true);
 
     const TEXT_TINY    = 255;
     const TEXT_SMALL   = 255; /* deprecated, alias of TEXT_TINY */

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -373,6 +373,17 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('int(11) unsigned', $rows[1]['Type']);
     }
 
+    public function testAddBooleanColumnWithSignedEqualsFalse()
+    {
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->save();
+        $this->assertFalse($table->hasColumn('test_boolean'));
+        $table->addColumn('test_boolean', 'boolean', array('signed' => false))
+              ->save();
+        $rows = $this->adapter->fetchAll('SHOW COLUMNS FROM table1');
+        $this->assertEquals('tinyint(1) unsigned', $rows[1]['Type']);
+    }
+
     public function testAddStringColumnWithSignedEqualsFalse()
     {
         $table = new \Phinx\Db\Table('table1', array(), $this->adapter);


### PR DESCRIPTION
This pull request
- Add boolean to array of allowed signed types in the MySQL Adapter - which seems the only adapter the signed option applies to.
- Adds a test for adding an unsigned boolean
- Update docs to indicate boolean and decimal values can be signed when using the MySQL adapter

It fixes #490.