### PR TITLE
Using a binary type with the MySQL driver should produce a binary column

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -54,6 +54,7 @@ interface AdapterInterface
     const PHINX_TYPE_TIME           = 'time';
     const PHINX_TYPE_DATE           = 'date';
     const PHINX_TYPE_BINARY         = 'binary';
+    const PHINX_TYPE_BLOB           = 'blob';
     const PHINX_TYPE_BOOLEAN        = 'boolean';
     const PHINX_TYPE_JSON           = 'json';
     const PHINX_TYPE_JSONB          = 'jsonb';

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -743,6 +743,9 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'text');
                 break;
             case static::PHINX_TYPE_BINARY:
+                return array('name' => 'binary', 'limit' => $limit ? $limit : 255);
+                break;
+            case static::PHINX_TYPE_BLOB:
                 if ($limit) {
                     $sizes = array(
                         // Order matters! Size must always be tested from longest to shortest!

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -455,6 +455,7 @@ abstract class PdoAdapter implements AdapterInterface
             'timestamp',
             'time',
             'date',
+            'blob',
             'binary',
             'boolean',
             'uuid',

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -746,6 +746,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             case static::PHINX_TYPE_DATETIME:
             case static::PHINX_TYPE_TIMESTAMP:
                 return array('name' => 'timestamp');
+            case static::PHINX_TYPE_BLOB:
             case static::PHINX_TYPE_BINARY:
                 return array('name' => 'bytea');
             // Geospatial database types

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -856,6 +856,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
             case static::PHINX_TYPE_DATE:
                 return array('name' => 'date');
                 break;
+            case static::PHINX_TYPE_BLOB:
             case static::PHINX_TYPE_BINARY:
                 return array('name' => 'blob');
                 break;

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -900,6 +900,7 @@ ORDER BY T.[name], I.[index_id];";
             case static::PHINX_TYPE_DATE:
                 return array('name' => 'date');
                 break;
+            case static::PHINX_TYPE_BLOB:
             case static::PHINX_TYPE_BINARY:
                 return array('name' => 'varbinary');
                 break;

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -829,23 +829,28 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
 
         //blob combinations
         $this->assertEquals(array('name' => 'blob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB));
+        $this->assertEquals(array('name' => 'tinyblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB, MysqlAdapter::BLOB_TINY));
+        $this->assertEquals(array('name' => 'tinyblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB, MysqlAdapter::BLOB_TINY+1));
+        $this->assertEquals(array('name' => 'blob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB, MysqlAdapter::BLOB_REGULAR));
+        $this->assertEquals(array('name' => 'blob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB, MysqlAdapter::BLOB_REGULAR+1));
+        $this->assertEquals(array('name' => 'mediumblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB, MysqlAdapter::BLOB_MEDIUM));
+        $this->assertEquals(array('name' => 'mediumblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB, MysqlAdapter::BLOB_MEDIUM+1));
+        $this->assertEquals(array('name' => 'longblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB, MysqlAdapter::BLOB_LONG));
+        $this->assertEquals(array('name' => 'longblob'),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB, MysqlAdapter::BLOB_LONG+1));
+
+        $this->assertEquals(array('name' => 'binary', 'limit' => 255),
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY));
-        $this->assertEquals(array('name' => 'tinyblob'),
-                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_TINY));
-        $this->assertEquals(array('name' => 'tinyblob'),
-                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_TINY+1));
-        $this->assertEquals(array('name' => 'blob'),
-                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_REGULAR));
-        $this->assertEquals(array('name' => 'blob'),
-                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_REGULAR+1));
-        $this->assertEquals(array('name' => 'mediumblob'),
-                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_MEDIUM));
-        $this->assertEquals(array('name' => 'mediumblob'),
-                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_MEDIUM+1));
-        $this->assertEquals(array('name' => 'longblob'),
-                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_LONG));
-        $this->assertEquals(array('name' => 'longblob'),
-                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, MysqlAdapter::BLOB_LONG+1));
+        $this->assertEquals(array('name' => 'binary', 'limit' => 36),
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY, 36));
 
         //int combinations
         $this->assertEquals(array('name' => 'int', 'limit' => 11),
@@ -886,7 +891,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('name' => 'time'),
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_TIME));
         $this->assertEquals(array('name' => 'blob'),
-                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BINARY));
+                            $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BLOB));
         $this->assertEquals(array('name' => 'tinyint', 'limit' => 1),
                             $this->adapter->getSqlType(MysqlAdapter::PHINX_TYPE_BOOLEAN));
         $this->assertEquals(array('name' => 'geometry'),


### PR DESCRIPTION
Currently, if you define a column as ``binary`` when using the MySQL driver, you get a ``blob``.
The problem is that ``binary`` is a valid type for MySQL and it is currently not possible to get one.

This PR aims to correct this.
A new ``BLOB`` type was added to the constants of the ``AdapterInterface``.
If it is used with other drivers than MySQL, it will produce the same result as using the ``binary`` type.