### PR TITLE
Fix dropForeignKey for SQLite

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -770,7 +770,11 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         $this->execute(sprintf('ALTER TABLE %s RENAME TO %s', $this->quoteTableName($tableName), $tmpTableName));
 
         foreach ($columns as $columnName) {
-            $sql = preg_replace(sprintf("/,[^,]*\(%s\) REFERENCES[^,]*\([^\)]*\)/", $this->quoteColumnName($columnName)), '', $sql, 1);
+            $search = sprintf(
+                "/,[^,]*\(%s(?:,`?(.*)`?)?\) REFERENCES[^,]*\([^\)]*\)[^,)]*/",
+                $this->quoteColumnName($columnName)
+            );
+            $sql = preg_replace($search, '', $sql, 1);
         }
 
         $this->execute($sql);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -501,10 +501,10 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $secondFk->setReferencedTable($refTable)
            ->setColumns(array('ref_table_field'))
            ->setReferencedColumns(array('field1'))
-           ->setOptions([
+           ->setOptions(array(
                'update' => 'CASCADE',
                'delete' => 'CASCADE'
-           ]);
+           ));
 
         $this->adapter->addForeignKey($table, $fk);
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), array('ref_table_id')));

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -490,24 +490,35 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $refTable->addColumn('field1', 'string')->save();
 
         $table = new \Phinx\Db\Table('table', array(), $this->adapter);
-        $table->addColumn('ref_table_id', 'integer')->save();
+        $table->addColumn('ref_table_id', 'integer')->addColumn('ref_table_field', 'string')->save();
 
         $fk = new \Phinx\Db\Table\ForeignKey();
         $fk->setReferencedTable($refTable)
            ->setColumns(array('ref_table_id'))
            ->setReferencedColumns(array('id'));
 
+        $secondFk = new \Phinx\Db\Table\ForeignKey();
+        $secondFk->setReferencedTable($refTable)
+           ->setColumns(array('ref_table_field'))
+           ->setReferencedColumns(array('field1'))
+           ->setOptions([
+               'update' => 'CASCADE',
+               'delete' => 'CASCADE'
+           ]);
+
         $this->adapter->addForeignKey($table, $fk);
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), array('ref_table_id')));
 
         $this->adapter->dropForeignKey($table->getName(), array('ref_table_id'));
         $this->assertFalse($this->adapter->hasForeignKey($table->getName(), array('ref_table_id')));
 
+        $this->adapter->addForeignKey($table, $secondFk);
         $this->adapter->addForeignKey($table, $fk);
         $this->assertTrue($this->adapter->hasForeignKey($table->getName(), array('ref_table_id')));
+        $this->assertTrue($this->adapter->hasForeignKey($table->getName(), array('ref_table_field')));
 
-        $this->adapter->dropForeignKey($table->getName(), array('ref_table_id'));
-        $this->assertFalse($this->adapter->hasForeignKey($table->getName(), array('ref_table_id')));
+        $this->adapter->dropForeignKey($table->getName(), array('ref_table_field'));
+        $this->assertTrue($this->adapter->hasTable($table->getName()));
     }
 
     public function testHasDatabase()


### PR DESCRIPTION
Currently, if you define a foreign key constraint with ``ON UPDATE`` and ``ON DELETE`` statements in SQLite, under specific circumstances, the constraint drop results in an error as the new table is not created.

Take the example I added in the SQLiteAdapterTest file.
Given how the constraints are added, the create script is :

```sql
CREATE TABLE `table` (
	`id` INTEGER NULL PRIMARY KEY AUTOINCREMENT,
	`ref_table_id` INTEGER,
	`ref_table_field` VARCHAR(255),
	FOREIGN KEY (`ref_table_field`) REFERENCES `ref_table` (`field1`) ON DELETE CASCADE ON UPDATE CASCADE,
	FOREIGN KEY (`ref_table_id`) REFERENCES `ref_table` (`id`)
)
```

When this query is fed to the ``preg_replace()`` call that was modified in the SQLiteAdapter if a ``dropForeignKey('table', array('ref_table_field'))`` is done, it will result in :

```sql
CREATE TABLE `table` (
	`id` INTEGER NULL PRIMARY KEY AUTOINCREMENT,
	`ref_table_id` INTEGER,
	`ref_table_field` VARCHAR(255) ON DELETE CASCADE ON UPDATE CASCADE,
	FOREIGN KEY (`ref_table_id`) REFERENCES `ref_table` (`id`)
)
```

Which is invalid and will not "re-create" the table, having the consequence to simply dropping the table.
This PR aims to fix this by modifying the regex in two parts :
- after the ``REFERENCES `$reftable` (`$refcolumn`)`` part by making the regex go down to a ``,`` or a ``)`` which makes the regex eat up the ``ON DELETE`` and ``ON UPDATE`` part as well.
- after the ``FOREIGN KEY ($column`` part by allowing other columns to be defined in case of composite foreign key constraints (which would mean that any constraints that column is bound to, whether simple or composite, will be dropped)

This covers the need I have (and fix the bug I had), so feel free to test this and give me feedback in case there are things I did not considered before merging.