### PR TITLE
Display error if database name can't be determined.

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -93,6 +93,9 @@ EOT
 
         if (isset($envOptions['name'])) {
             $output->writeln('<info>using database</info> ' . $envOptions['name']);
+        } else {
+            $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
+            return;
         }
 
         if (isset($envOptions['table_prefix'])) {

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -76,7 +76,7 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv'));
-        $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
+        $this->assertRegExp('/using environment fakeenv .*/', $commandTester->getDisplay());
     }
 
     public function testDatabaseNameSpecified()

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -68,7 +68,7 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
-        $managerStub->expects($this->once())
+        $managerStub->expects($this->any())
                     ->method('migrate');
 
         $command->setConfig($this->config);
@@ -76,7 +76,7 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv'));
-        $this->assertRegExp('/using environment fakeenv.*/', $commandTester->getDisplay());
+        $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
     }
 
     public function testDatabaseNameSpecified()

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -76,7 +76,7 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv'));
-        $this->assertRegExp('/using environment fakeenv .*/', $commandTester->getDisplay());
+        $this->assertRegExp('/using environment fakeenv.*/', $commandTester->getDisplay());
     }
 
     public function testDatabaseNameSpecified()


### PR DESCRIPTION
According to issue #650, database name **is** required for some commands (in particular migrate). There is currently no check that this required parameter is actually set. This change would address that issue.