### PR TITLE
Allow to pass table option signed for primary key

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -213,6 +213,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
             $column = new Column();
             $column->setName('id')
                    ->setType('integer')
+                   ->setSigned(isset($options['signed']) ? $options['signed'] : false)
                    ->setIdentity(true);
 
             array_unshift($columns, $column);


### PR DESCRIPTION
Discussed in #657.

Primary field by default have to be unsigned because for autoincrement this is only that makes sense. But just in case there is parameter that you can pass to change that.