### PR TITLE
[MySQL] Custom collation for just one column in table

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -932,6 +932,14 @@ scale     combine with ``precision`` to set decimial accuracy
 signed    enable or disable the ``unsigned`` option *(only applies to MySQL)*
 ========= ===========
 
+For ``string`` and ``text`` columns:
+
+========= ===========
+Option    Description
+========= ===========
+collation set collation that differs from table defaults
+========= ===========
+
 For ``enum`` and ``set`` columns:
 
 ========= ===========

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -938,6 +938,7 @@ For ``string`` and ``text`` columns:
 Option    Description
 ========= ===========
 collation set collation that differs from table defaults
+encoding  set character set that differs from table defaults
 ========= ===========
 
 For ``enum`` and ``set`` columns:

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1007,6 +1007,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         if (($values = $column->getValues()) && is_array($values)) {
             $def .= "('" . implode("', '", $values) . "')";
         }
+        $def .= $column->getCollation() ? ' COLLATE ' . $column->getCollation() : '';
         $def .= (!$column->isSigned() && isset($this->signedColumnTypes[$column->getType()])) ? ' unsigned' : '' ;
         $def .= ($column->isNull() == false) ? ' NOT NULL' : ' NULL';
         $def .= ($column->isIdentity()) ? ' AUTO_INCREMENT' : '';

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1007,6 +1007,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         if (($values = $column->getValues()) && is_array($values)) {
             $def .= "('" . implode("', '", $values) . "')";
         }
+        $def .= $column->getEncoding() ? ' CHARACTER SET ' . $column->getEncoding() : '';
         $def .= $column->getCollation() ? ' COLLATE ' . $column->getCollation() : '';
         $def .= (!$column->isSigned() && isset($this->signedColumnTypes[$column->getType()])) ? ' unsigned' : '' ;
         $def .= ($column->isNull() == false) ? ' NOT NULL' : ' NULL';

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -27,6 +27,7 @@
  * @subpackage Phinx\Db
  */
 namespace Phinx\Db\Table;
+use Phinx\Db\Adapter\AdapterInterface;
 
 /**
  *
@@ -109,10 +110,19 @@ class Column
      *
      * @param string $collation
      *
-     * @return Column
+     * @throws \UnexpectedValueException If collation not allowed for type
+     * @return $this
      */
     public function setCollation($collation)
     {
+        $allowedTypes = [
+            AdapterInterface::PHINX_TYPE_CHAR,
+            AdapterInterface::PHINX_TYPE_STRING,
+            AdapterInterface::PHINX_TYPE_TEXT,
+        ];
+        if (!in_array($this->getType(), $allowedTypes))
+            throw new \UnexpectedValueException("Collation may be set only for types: ". implode(', ', $allowedTypes));
+
         $this->collation = $collation;
 
         return $this;

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -115,11 +115,11 @@ class Column
      */
     public function setCollation($collation)
     {
-        $allowedTypes = [
+        $allowedTypes = array(
             AdapterInterface::PHINX_TYPE_CHAR,
             AdapterInterface::PHINX_TYPE_STRING,
             AdapterInterface::PHINX_TYPE_TEXT,
-        ];
+        );
         if (!in_array($this->getType(), $allowedTypes))
             throw new \UnexpectedValueException("Collation may be set only for types: ". implode(', ', $allowedTypes));
 

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -96,6 +96,11 @@ class Column
     protected $collation;
 
     /**
+     * @var string
+     */
+    protected $encoding;
+
+    /**
      * Gets the column collation.
      *
      * @return string
@@ -124,6 +129,39 @@ class Column
             throw new \UnexpectedValueException("Collation may be set only for types: ". implode(', ', $allowedTypes));
 
         $this->collation = $collation;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column character set.
+     *
+     * @return string
+     */
+    public function getEncoding()
+    {
+        return $this->encoding;
+    }
+
+    /**
+     * Sets the column character set.
+     *
+     * @param string $encoding
+     *
+     * @throws \UnexpectedValueException If character set not allowed for type
+     * @return $this
+     */
+    public function setEncoding($encoding)
+    {
+        $allowedTypes = array(
+            AdapterInterface::PHINX_TYPE_CHAR,
+            AdapterInterface::PHINX_TYPE_STRING,
+            AdapterInterface::PHINX_TYPE_TEXT,
+        );
+        if (!in_array($this->getType(), $allowedTypes))
+            throw new \UnexpectedValueException("Character set may be set only for types: ". implode(', ', $allowedTypes));
+
+        $this->encoding = $encoding;
 
         return $this;
     }
@@ -546,6 +584,7 @@ class Column
             'properties',
             'values',
             'collation',
+            'encoding',
         );
     }
 

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -90,6 +90,35 @@ class Column
     protected $comment;
 
     /**
+     * @var string
+     */
+    protected $collation;
+
+    /**
+     * Gets the column collation.
+     *
+     * @return string
+     */
+    public function getCollation()
+    {
+        return $this->collation;
+    }
+
+    /**
+     * Sets the column collation.
+     *
+     * @param string $collation
+     *
+     * @return Column
+     */
+    public function setCollation($collation)
+    {
+        $this->collation = $collation;
+
+        return $this;
+    }
+
+    /**
      * @var boolean
      */
     protected $signed = true;
@@ -506,6 +535,7 @@ class Column
             'timezone',
             'properties',
             'values',
+            'collation',
         );
     }
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -402,6 +402,19 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('varchar(255)', $rows[1]['Type']);
     }
 
+    public function testAddStringColumnWithCustonCollation()
+    {
+        $table = new \Phinx\Db\Table('table1', array('collation' => 'utf8_general_ci'), $this->adapter);
+        $table->save();
+        $this->assertFalse($table->hasColumn('string_collation_default'));
+        $this->assertFalse($table->hasColumn('string_collation_custom'));
+        $table->addColumn('string_collation_default', 'string', array())->save();
+        $table->addColumn('string_collation_custom', 'string', array('collation' => 'utf8mb4_unicode_ci'))->save();
+        $rows = $this->adapter->fetchAll('SHOW FULL COLUMNS FROM table1');
+        $this->assertEquals('utf8_general_ci', $rows[2]['Collation']);
+        $this->assertEquals('utf8mb4_unicode_ci', $rows[3]['Collation']);
+    }
+
     public function testRenameColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);


### PR DESCRIPTION
For issue #661 – add support collation for MySQL adapter. Now allowed this usage:

```php
// ... Somewhere in migration ...
$this->table('foo')
    ->setOptions([
        'encoding'  => 'utf8',
        'collation' => 'utf8_general_ci',
    ])
    ->addColumn('text_one', 'string')
    ->addColumn('text_two', 'string', ['collation' => 'utf8mb4_unicode_ci''])
    ->save()
;
```