### PR TITLE
Add $version variable to be passed into templates

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -210,6 +210,7 @@ class Create extends AbstractCommand
         $classes = array(
             '$useClassName'  => $this->getConfig()->getMigrationBaseClassName(false),
             '$className'     => $className,
+            '$version'       => Util::getVersionFromFileName($fileName),
             '$baseClassName' => $this->getConfig()->getMigrationBaseClassName(true),
         );
         $contents = strtr($contents, $classes);


### PR DESCRIPTION
We see a need to use the $version in the templates to create better backups and restores. 