### PR TITLE
Fixed rollbacks

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -74,9 +74,10 @@ interface AdapterInterface
     /**
      * Get all migrated version numbers.
      *
+     * @param bool $fullRow
      * @return array
      */
-    public function getVersions();
+    public function getVersions($fullRow = false);
 
     /**
      * Set adapter configuration options.

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -74,10 +74,10 @@ interface AdapterInterface
     /**
      * Get all migrated version numbers.
      *
-     * @param bool $fullRow
+     * @param bool $fullVersion Get the entire version row, not just the version number.
      * @return array
      */
-    public function getVersions($fullRow = false);
+    public function getVersions($fullVersion = false);
 
     /**
      * Set adapter configuration options.

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -184,9 +184,9 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * {@inheritdoc}
      */
-    public function getVersions()
+    public function getVersions($fullRow = false)
     {
-        return $this->getAdapter()->getVersions();
+        return $this->getAdapter()->getVersions($fullRow);
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -354,11 +354,11 @@ abstract class PdoAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getVersions($fullRow = false)
+    public function getVersions($fullVersion = false)
     {
         $result = array();
         $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY version ASC', $this->getSchemaTableName()));
-        if ($fullRow) {
+        if ($fullVersion) {
             foreach($rows as $v) {
                 $result[$v['version']] = $v;
             }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -354,15 +354,24 @@ abstract class PdoAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getVersions()
+    public function getVersions($fullRow = false)
     {
+        $result = array();
         $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY version ASC', $this->getSchemaTableName()));
-        return array_map(
-            function ($v) {
-                return $v['version'];
-            },
-            $rows
-        );
+        if ($fullRow) {
+            foreach($rows as $v) {
+                $result[$v['version']] = $v;
+            }
+        } else {
+            $result = array_map(
+                function ($v) {
+                    return $v['version'];
+                },
+                $rows
+            );
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -85,7 +85,7 @@ class Manager
             $env = $this->getEnvironment($environment);
             $versions = $env->getFullVersions();
 
-            foreach ( $this->getMigrations() as $migration) {
+            foreach ($this->getMigrations() as $migration) {
                 $version = array_key_exists($migration->getVersion(), $versions) ? $versions[$migration->getVersion()] : false;
                 if ($version) {
                     $status = '     <info>up</info> ';
@@ -331,7 +331,7 @@ class Manager
         }
 
         // Sort the migration(s) by descending start time (ie. the opposite order of the version names, which
-        // where sorted by ascending start time earlier)
+        // were sorted by ascending start time earlier)
         $sortedMigrations = array();
 
         while ($versionName = array_pop($versionNames)) {

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -198,7 +198,19 @@ class Environment
      */
     public function getVersions()
     {
-        return $this->getAdapter()->getVersions();
+        return $this->getAdapter()->getVersions(false);
+    }
+
+    /**
+     * Gets all migrated version rows.
+     *
+     * This will include the breakpoint marker.
+     *
+     * @return array
+     */
+    public function getFullVersions()
+    {
+        return $this->getAdapter()->getVersions(true);
     }
 
     /**

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Console\Command;
 
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\StreamOutput;
 use Phinx\Config\Config;
@@ -45,13 +46,37 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         // mock the manager class
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
         $managerStub->expects($this->once())
-                    ->method('printStatus');
+            ->method('printStatus');
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName()));
+
+        $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithVerbosity()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Status());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('status');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub->expects($this->once())
+            ->method('printStatus');
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()), array('verbosity' => OutputInterface::VERBOSITY_VERBOSE));
 
         $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
     }
@@ -69,13 +94,36 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         // mock the manager class
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
         $managerStub->expects($this->once())
-                    ->method('printStatus');
+            ->method('printStatus');
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv'));
+        $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv'), array('verbosity' => OutputInterface::VERBOSITY_VERBOSE));
+        $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithEnvironmentOptionWithVerbosity()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Status());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('status');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub->expects($this->once())
+            ->method('printStatus');
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv'), array('verbosity' => OutputInterface::VERBOSITY_VERBOSE));
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
     }
 
@@ -92,13 +140,36 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         // mock the manager class
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
         $managerStub->expects($this->once())
-                    ->method('printStatus');
+            ->method('printStatus');
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--format' => 'json'));
+        $this->assertRegExp('/using format json/', $commandTester->getDisplay());
+    }
+
+    public function testFormatSpecifiedWithVerbosity()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Status());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('status');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub->expects($this->once())
+            ->method('printStatus');
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '--format' => 'json'), array('verbosity' => OutputInterface::VERBOSITY_VERBOSE));
         $this->assertRegExp('/using format json/', $commandTester->getDisplay());
     }
 }

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -243,19 +243,44 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider rollbackDateDataProvider
      */
-    public function testRollbacksByDate($availableRollbacks, $availableRollbacksFullRow, $dateString, $expectedRollback)
+    public function testRollbacksByDate($availableRollbacksFullRow, $dateString, $expectedRollback)
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->any())
-            ->method('getVersions')
-            ->will($this->returnValue($availableRollbacks));
+            ->method('getFullVersions')
+            ->will($this->returnValue($availableRollbacksFullRow));
+        
+        // stub manager
+        $config = new Config($this->getConfigArray());
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array('rollback'), array($config, $output));
+
+        $managerStub->expects($this->once())
+            ->method('rollback')
+            ->with($this->equalTo('mockenv'), $expectedRollback)
+            ->will($this->returnValue($availableRollbacksFullRow));
+
+        $managerStub->setEnvironments(array('mockenv' => $envStub));
+        $managerStub->rollbackToDateTime('mockenv', new \DateTime($dateString));
+    }
+
+    /**
+     * Test that migrating by version chooses the correct
+     * migration to point to.
+     *
+     * @dataProvider rollbackVersionDataProvider
+     */
+    public function testRollbacksByVersion($availableRollbacksFullRow, $version, $expectedRollback)
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->any())
             ->method('getFullVersions')
             ->will($this->returnValue($availableRollbacksFullRow));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
-        $this->manager->rollbackToDateTime('mockenv', new \DateTime($dateString));
+        $this->manager->rollback('mockenv', $version);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedRollback)) {
@@ -312,33 +337,74 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(
-                array('20120111235330', '20120116183504', '20120120183504'),
                 array(
-                    array('version' => '20120111235330'),
-                    array('version' => '20120116183504'),
-                    array('version' => '20120120183504')
+                    '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-11 23:53:30'),
+                    '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04'),
+                    '20120120183504' => array('version' => '20120120183504', 'start_time' => '2012-01-20 18:35:04')
                 ),
                 '20120118',
                 '20120116183504'
             ),
             array(
-                array('20120111235330', '20120116183504'),
                 array(
-                    array('version' => '20120111235330'),
-                    array('version' => '20120116183504')
+                    '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-11 23:53:30'),
+                    '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04'),
                 ),
                 '20120115',
                 '20120111235330'
             ),
             array(
-                array('20120111235330', '20120116183504'),
                 array(
-                    array('version' => '20120111235330'),
-                    array('version' => '20120116183504')
+                    '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-11 23:53:30'),
+                    '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04')
                 ),
                 '20110115',
-                '20120111235330'
+                '0'
             ),
+            array(
+                array(
+                    '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-22 23:53:30'),
+                    '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04'),
+                ),
+                '20120121',
+                '20120116183504'
+            )
+        );
+    }
+
+    /**
+     * Migration lists (versionOnly and fullRow), dates, and expected migrations to point to.
+     *
+     * @return array
+     */
+    public function rollbackVersionDataProvider()
+    {
+        return array(
+            array(
+                array(
+                    '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-11 23:53:30'),
+                    '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04'),
+                    '20120120183504' => array('version' => '20120120183504', 'start_time' => '2012-01-20 18:35:04')
+                ),
+                '20120111235330',
+                '20120116183504'
+            ),
+            array(
+                array(
+                    '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-11 23:53:30'),
+                    '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04'),
+                ),
+                '20120116183504',
+                null
+            ),
+            array(
+                array(
+                    '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-11 23:53:30'),
+                    '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04')
+                ),
+                '0',
+                '20120111235330'
+            )
         );
     }
 
@@ -397,6 +463,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($adapter->hasTable('info'));
         $this->assertFalse($adapter->hasTable('statuses'));
         $this->assertFalse($adapter->hasTable('user_logins'));
+        $this->assertTrue($adapter->hasTable('users'));
         $this->assertTrue($adapter->hasColumn('users', 'bio'));
         $this->assertFalse($adapter->hasForeignKey('user_logins', array('user_id')));
     }


### PR DESCRIPTION
(as discussed in https://github.com/robmorgan/phinx/issues/628)

When rollbacking migrations, their order is now determined by when they were executed (ie. their Start Time) as opposed to when they were created (ie. their version name).
    
This means:
* With no parameters, the rollback command will rollback the last executed migration.
* With the -d (date) parameter, the migration start times are now used to determine the target version to rollback to. In other words, all migrations which were executed after that date will be rollbacked.
* With the -t (target version) parameter, all migrations which were executed after that version was executed will be rollbacked.

In terms of testing:
* The `testRollbacksByDate` test was changed to be more "unit"y, ie. it now asserts the rollback method is called with the right version (instead of asserting the right version is rollbacked). A few test cases were also added to it (via its provider).
* The `testRollbacksByVersion` was added.

A few notes:
* I based my work on https://github.com/robmorgan/phinx/pull/664 as I needed access to the Migration Start Times, I hope that's fine (the comment on the PR suggests it will be accepted anyway).
* I understand my approach is quite a game changer, as it completely changes the concept of "previous migration" and how the "-d" parameter works, but I couldn't see any other way to solve this.
* Seeing as how the execution times are the "norm" in this approach, the Status command should probably also be changed to order the Up migrations by execution time instead of name, but I couldn't decide on what ordering made sense with regards to up, down and missing migrations, so I didn't change it.


