### PR TITLE
Updated migrations.rst to correct usage of CURRENT_TIMESTAMP.

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -387,7 +387,7 @@ To simply change the name of the primary key, we need to override the default ``
             {
                 $table = $this->table('followers', array('id' => 'user_id'));
                 $table->addColumn('follower_id', 'integer')
-                      ->addColumn('created', 'datetime', array('default' => 'CURRENT_TIMESTAMP'))
+                      ->addColumn('created', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
                       ->save();
             }
 


### PR DESCRIPTION
The documentation for "Creating a Table" was using CURRENT_TIMESTAMP on a datetime field instead of a timestamp field.