### PR TITLE
Added support for Symfony3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     }],
     "require": {
         "php": ">=5.3.2",
-        "symfony/console": "~2.7",
-        "symfony/config": "~2.7",
-        "symfony/yaml": "~2.7"
+        "symfony/console": "~2.7|~3.0",
+        "symfony/config": "~2.7|~3.0",
+        "symfony/yaml": "~2.7|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,10 +27,10 @@ This means that:
   any global variables your initialization file reads or modifies.
 * Its standard output is suppressed.
 * Unlike with JSON and YAML, it is possible to omit environment connection details
-  and instead specify ``connection`` which must
-  contain an initialized PDO instance. This is useful when you want
-  your migrations to interact with your application and/or share the same.
-  connection.
+  and instead specify ``connection`` which must contain an initialized PDO instance.
+  This is useful when you want your migrations to interact with your application
+  and/or share the same connection. However remember to also pass the database name
+  as Phinx cannot infer this from the PDO connection.
 
 .. code-block:: php
 
@@ -39,11 +39,15 @@ This means that:
    global $app;
    $pdo = $app->getDatabase()->getPdo();
 
-   return array('environments' => array(
-            'default_database' => 'development',
-            'development' => array(
-            'connection' => $pdo
-            )));
+   return array('environments' =>
+            array(
+              'default_database' => 'development',
+              'development' => array(
+                'name' => 'devdb',
+                'connection' => $pdo
+              )
+            )
+          );
 
 Migration Path
 --------------


### PR DESCRIPTION
I've locally bumped phinx to use Symfony3 and all the tests pass.
To me it looks like phinx work out of the box with the soon to be released so I propose to make the `composer.json` compatible with it.