### PR TITLE
Status Command now returns proper exit code

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -110,6 +110,11 @@ status. You can use this command to determine which migrations have been run.
 
         $ phinx status -e development
 
+This command exits with code 0 if the database is up-to-date (ie. all migrations are up) or one of the following codes otherwise:
+
+* 1: There is at least one down migration.
+* 2: There is at least one missing migration.
+
 The Seed Create Command
 -----------------------
 

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -61,7 +61,7 @@ EOT
      *
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return void
+     * @return integer 0 if all migrations are up, or an error code
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -81,6 +81,6 @@ EOT
         }
 
         // print the status
-        $this->getManager()->printStatus($environment, $format);
+        return $this->getManager()->printStatus($environment, $format);
     }
 }

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -45,14 +45,16 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         // mock the manager class
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
         $managerStub->expects($this->once())
-                    ->method('printStatus');
+                    ->method('printStatus')
+                    ->will($this->returnValue(0));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName()));
+        $return = $commandTester->execute(array('command' => $command->getName()));
 
+        $this->assertEquals(0, $return);
         $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
     }
 
@@ -69,13 +71,15 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         // mock the manager class
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
         $managerStub->expects($this->once())
-                    ->method('printStatus');
+                    ->method('printStatus')
+                    ->will($this->returnValue(0));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv'));
+        $return = $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv'));
+        $this->assertEquals(0, $return);
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
     }
 
@@ -92,13 +96,15 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         // mock the manager class
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
         $managerStub->expects($this->once())
-                    ->method('printStatus');
+                    ->method('printStatus')
+                    ->will($this->returnValue(0));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName(), '--format' => 'json'));
+        $return = $commandTester->execute(array('command' => $command->getName(), '--format' => 'json'));
+        $this->assertEquals(0, $return);
         $this->assertRegExp('/using format json/', $commandTester->getDisplay());
     }
 }


### PR DESCRIPTION
Status command exit codes:
0: all migrations are up
1: at least one migration is down
2: at least one migration is missing

Fixes robmorgan/phinx#676