### PR TITLE
Defaults for the source of the template (a generator class or a file)…

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -133,19 +133,24 @@ class Create extends AbstractCommand
             ));
         }
 
-        // Get the alternative template and static class options, but only allow one of them.
+        // Get the alternative template and static class options from the config, but only allow one of them.
+        $defaultAltTemplate = $this->getConfig()->getTemplateFile();
+        $defaultCreationClassName = $this->getConfig()->getTemplateClass();
+        if ($defaultAltTemplate && $defaultCreationClassName){
+            throw new \InvalidArgumentException('Cannot define template:class and template:file at the same time');
+        }
+
+        // Get the alternative template and static class options from the command line, but only allow one of them.
         $altTemplate = $input->getOption('template');
-        if (!$altTemplate) {
-            $altTemplate = $this->getConfig()->getTemplateFile();
-        }
-
         $creationClassName = $input->getOption('class');
-        if (!$creationClassName) {
-            $creationClassName = $this->getConfig()->getTemplateClass();
-        }
-
         if ($altTemplate && $creationClassName) {
             throw new \InvalidArgumentException('Cannot use --template and --class at the same time');
+        }
+
+        // If no commandline options then use the defaults.
+        if (!$altTemplate && !$creationClassName){
+            $altTemplate = $defaultAltTemplate;
+            $creationClassName = $defaultCreationClassName;
         }
 
         // Verify the alternative template file's existence.

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -57,4 +57,58 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         sleep(1.01); // need at least a second due to file naming scheme
         $commandTester->execute(array('command' => $command->getName(), 'name' => 'MyDuplicateMigration'));
     }
+
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Cannot use --template and --class at the same time
+     */
+    public function testSupplyingBothClassAndTemplateAtCommandLineThrowsException()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Create());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('create');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), 'name' => 'MyFailingMigration', '--template' => 'MyTemplate', '--class' => 'MyTemplateClass'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Cannot define template:class and template:file at the same time
+     */
+    public function testSupplyingBothClassAndTemplateInConfigThrowsException()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Create());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('create');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+
+        $this->config['templates'] = array(
+            'file' => 'MyTemplate',
+            'class' => 'MyTemplateClass'
+        );
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), 'name' => 'MyFailingMigration'));
+    }
 }


### PR DESCRIPTION
… can be overwritten by the command line options. In both cases, you cannot define/provide both values.

Also, if you define the class but supply the template on the command line (or vice versa), the command line options take precedence.