### PR TITLE
PHP 5.3 is no longer supported by phinx.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_script:
     - psql -c 'create database phinx_testing;' -U postgres
 language: php
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -26,7 +25,7 @@ matrix:
         - php: hhvm
           env: TESTS_PHINX_DB_ADAPTER_POSTGRES_ENABLED=true
     include:
-        - php: 5.3
+        - php: 5.4
           env: SYMFONY_VERSION='~2.8'
         - php: hhvm
           env: TESTS_PHINX_DB_ADAPTER_POSTGRES_ENABLED=false


### PR DESCRIPTION
As composer.json says PHP must be >= 5.4, no point in testing against PHP 5.3.