### PR TITLE
Capturing migrations with GLOB_BRACE

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -75,6 +75,14 @@ You can also use the ``%%PHINX_CONFIG_DIR%%`` token in your path.
     paths:
         migrations: %%PHINX_CONFIG_DIR%%/your/relative/path
 
+Migrations are captured with ``glob``, so you can define a pattern for multiple
+directories.
+
+.. code-block:: yaml
+
+    paths:
+        migrations: %%PHINX_CONFIG_DIR%%/module/*/{data,scripts}/migrations
+
 Custom Migration Base
 ---------------------
 

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -515,7 +515,7 @@ class Manager
     {
         if (null === $this->migrations) {
             $config = $this->getConfig();
-            $phpFiles = glob($config->getMigrationPath() . DIRECTORY_SEPARATOR . '*.php');
+            $phpFiles = glob($config->getMigrationPath() . DIRECTORY_SEPARATOR . '*.php', GLOB_BRACE);
 
             // filter the files to only get the ones that match our naming scheme
             $fileNames = array();


### PR DESCRIPTION
I just enable `GLOB_BRACE` to capture migrations in multiple directories.

Example:

```php
<?php
return [
    'paths' => [
        'migrations' => '%%PHINX_CONFIG_DIR%%/module/Module{A,B}/migrations',
    ],
];
```