### PR TITLE
Migrate::execute() now returns exit code

### DIFF
--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -65,7 +65,7 @@ EOT
      *
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return void
+     * @return integer integer 0 on success, or an error code.
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -95,7 +95,7 @@ EOT
             $output->writeln('<info>using database</info> ' . $envOptions['name']);
         } else {
             $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
-            return;
+            return 1;
         }
 
         if (isset($envOptions['table_prefix'])) {
@@ -116,5 +116,7 @@ EOT
 
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+
+        return 0;
     }
 }

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -51,9 +51,10 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
+        $exitCode = $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
 
         $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
+        $this->assertSame(0, $exitCode);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -75,8 +76,10 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv'), array('decorated' => false));
+        $exitCode = $commandTester->execute(array('command' => $command->getName(), '--environment' => 'fakeenv'), array('decorated' => false));
+
         $this->assertRegExp('/using environment fakeenv/', $commandTester->getDisplay());
+        $this->assertSame(1, $exitCode);
     }
 
     public function testDatabaseNameSpecified()
@@ -98,7 +101,9 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
         $command->setManager($managerStub);
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
+        $exitCode = $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
+
         $this->assertRegExp('/using database development/', $commandTester->getDisplay());
+        $this->assertSame(0, $exitCode);
     }
 }


### PR DESCRIPTION
Hi. I just made it so that it returns 1 if the environment doesn't exist, and 0 for everything else.
It would probably be nicer to get a status from the actual migrations to see if they ran correctly, but I haven't looked into that.