### PR TITLE
Show names of missing migrations in status log

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -79,6 +79,13 @@ interface AdapterInterface
     public function getVersions();
 
     /**
+     * Get all migration log entries, indexed by version number.
+     *
+     * @return array
+     */
+    public function getVersionLog();
+
+    /**
      * Set adapter configuration options.
      *
      * @param  array $options

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -192,6 +192,14 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * {@inheritdoc}
      */
+    public function getVersionLog()
+    {
+        return $this->getAdapter()->getVersionLog();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)
     {
         $this->getAdapter()->migrated($migration, $direction, $startTime, $endTime);

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -183,9 +183,9 @@ abstract class PdoAdapter implements AdapterInterface
             $this->createSchemaTable();
         } else {
             $table = new Table($this->getSchemaTableName(), array(), $this);
-            if (!$table->hasColumn('name')) {
+            if (!$table->hasColumn('migration_name')) {
                 $table
-                    ->addColumn('name', 'string', array('limit' => 100))
+                    ->addColumn('migration_name', 'string', array('limit' => 100))
                     ->save();
             }
         }
@@ -432,13 +432,13 @@ abstract class PdoAdapter implements AdapterInterface
                 $table->addColumn('version', 'biginteger', array('limit' => 14))
                       ->addColumn('start_time', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
                       ->addColumn('end_time', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
-                      ->addColumn('name', 'string', array('limit' => 100))
+                      ->addColumn('migration_name', 'string', array('limit' => 100))
                       ->save();
             } else {
                 $table->addColumn('version', 'biginteger')
                       ->addColumn('start_time', 'timestamp')
                       ->addColumn('end_time', 'timestamp')
-                      ->addColumn('name', 'string', array('limit' => 100))
+                      ->addColumn('migration_name', 'string', array('limit' => 100))
                       ->save();
             }
         } catch (\Exception $exception) {

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -425,11 +425,13 @@ abstract class PdoAdapter implements AdapterInterface
                 $table->addColumn('version', 'biginteger', array('limit' => 14))
                       ->addColumn('start_time', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
                       ->addColumn('end_time', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
+                      ->addColumn('name', 'string', array('limit' => 100))
                       ->save();
             } else {
                 $table->addColumn('version', 'biginteger')
                       ->addColumn('start_time', 'timestamp')
                       ->addColumn('end_time', 'timestamp')
+                      ->addColumn('name', 'string', array('limit' => 100))
                       ->save();
             }
         } catch (\Exception $exception) {

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -390,7 +390,7 @@ abstract class PdoAdapter implements AdapterInterface
                 $migration->getVersion(),
                 $startTime,
                 $endTime,
-                $migration->getName()
+                substr($migration->getName(), 0, 100)
             );
 
             $this->query($sql);

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -361,13 +361,23 @@ abstract class PdoAdapter implements AdapterInterface
      */
     public function getVersions()
     {
+        $rows = $this->getVersionLog();
+
+        return array_keys($rows);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersionLog()
+    {
+        $result = array();
         $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY version ASC', $this->getSchemaTableName()));
-        return array_map(
-            function ($v) {
-                return $v['version'];
-            },
-            $rows
-        );
+        foreach($rows as $version) {
+            $result[$version['version']] = $version;
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -379,8 +379,9 @@ abstract class PdoAdapter implements AdapterInterface
             // up
             $sql = sprintf(
                 'INSERT INTO %s ('
-                . 'version, start_time, end_time'
+                . 'version, start_time, end_time, migration_name'
                 . ') VALUES ('
+                . '\'%s\','
                 . '\'%s\','
                 . '\'%s\','
                 . '\'%s\''
@@ -388,7 +389,8 @@ abstract class PdoAdapter implements AdapterInterface
                 $this->getSchemaTableName(),
                 $migration->getVersion(),
                 $startTime,
-                $endTime
+                $endTime,
+                $migration->getName()
             );
 
             $this->query($sql);

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -185,7 +185,7 @@ abstract class PdoAdapter implements AdapterInterface
             $table = new Table($this->getSchemaTableName(), array(), $this);
             if (!$table->hasColumn('migration_name')) {
                 $table
-                    ->addColumn('migration_name', 'string', array('limit' => 100))
+                    ->addColumn('migration_name', 'string', array('limit' => 100, 'after' => 'version'))
                     ->save();
             }
         }
@@ -389,7 +389,7 @@ abstract class PdoAdapter implements AdapterInterface
             // up
             $sql = sprintf(
                 'INSERT INTO %s ('
-                . 'version, start_time, end_time, migration_name'
+                . 'version, migration_name, start_time, end_time'
                 . ') VALUES ('
                 . '\'%s\','
                 . '\'%s\','
@@ -398,9 +398,9 @@ abstract class PdoAdapter implements AdapterInterface
                 . ');',
                 $this->getSchemaTableName(),
                 $migration->getVersion(),
+                substr($migration->getName(), 0, 100),
                 $startTime,
-                $endTime,
-                substr($migration->getName(), 0, 100)
+                $endTime
             );
 
             $this->query($sql);
@@ -442,15 +442,15 @@ abstract class PdoAdapter implements AdapterInterface
             if ($this->getConnection()->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'mysql'
                 && version_compare($this->getConnection()->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.6.0', '>=')) {
                 $table->addColumn('version', 'biginteger', array('limit' => 14))
+                      ->addColumn('migration_name', 'string', array('limit' => 100))
                       ->addColumn('start_time', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
                       ->addColumn('end_time', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
-                      ->addColumn('migration_name', 'string', array('limit' => 100))
                       ->save();
             } else {
                 $table->addColumn('version', 'biginteger')
+                      ->addColumn('migration_name', 'string', array('limit' => 100))
                       ->addColumn('start_time', 'timestamp')
                       ->addColumn('end_time', 'timestamp')
-                      ->addColumn('migration_name', 'string', array('limit' => 100))
                       ->save();
             }
         } catch (\Exception $exception) {

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -181,6 +181,13 @@ abstract class PdoAdapter implements AdapterInterface
         // Create the schema table if it doesn't already exist
         if (!$this->hasSchemaTable()) {
             $this->createSchemaTable();
+        } else {
+            $table = new Table($this->getSchemaTableName(), array(), $this);
+            if (!$table->hasColumn('name')) {
+                $table
+                    ->addColumn('name', 'string', array('limit' => 100))
+                    ->save();
+            }
         }
 
         return $this;

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -373,7 +373,7 @@ abstract class PdoAdapter implements AdapterInterface
     {
         $result = array();
         $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY version ASC', $this->getSchemaTableName()));
-        foreach($rows as $version) {
+        foreach ($rows as $version) {
             $result[$version['version']] = $version;
         }
 

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1042,11 +1042,12 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(
-                "INSERT INTO %s (version, start_time, end_time) VALUES ('%s', '%s', '%s');",
+                "INSERT INTO %s (version, start_time, end_time, migration_name) VALUES ('%s', '%s', '%s', '%s');",
                 $this->getSchemaTableName(),
                 $migration->getVersion(),
                 $startTime,
-                $endTime
+                $endTime,
+                $migration->getName()
             );
 
             $this->query($sql);

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1042,12 +1042,12 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(
-                "INSERT INTO %s (version, start_time, end_time, migration_name) VALUES ('%s', '%s', '%s', '%s');",
+                "INSERT INTO %s (version, migration_name, start_time, end_time) VALUES ('%s', '%s', '%s', '%s');",
                 $this->getSchemaTableName(),
                 $migration->getVersion(),
+                substr($migration->getName(), 0, 100),
                 $startTime,
-                $endTime,
-                substr($migration->getName(), 0, 100)
+                $endTime
             );
 
             $this->query($sql);

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1047,7 +1047,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 $migration->getVersion(),
                 $startTime,
                 $endTime,
-                $migration->getName()
+                substr($migration->getName(), 0, 100)
             );
 
             $this->query($sql);

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1172,12 +1172,12 @@ SQL;
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(
-                "INSERT INTO %s ([version], [start_time], [end_time], [migration_name]) VALUES ('%s', '%s', '%s', '%s');",
+                "INSERT INTO %s ([version], [migration_name], [start_time], [end_time]) VALUES ('%s', '%s', '%s', '%s');",
                 $this->getSchemaTableName(),
                 $migration->getVersion(),
+                substr($migration->getName(), 0, 100),
                 $startTime,
-                $endTime,
-                substr($migration->getName(), 0, 100)
+                $endTime
             );
 
             $this->query($sql);

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1177,7 +1177,7 @@ SQL;
                 $migration->getVersion(),
                 $startTime,
                 $endTime,
-                $migration->getName()
+                substr($migration->getName(), 0, 100)
             );
 
             $this->query($sql);

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1172,11 +1172,12 @@ SQL;
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(
-                "INSERT INTO %s ([version], [start_time], [end_time]) VALUES ('%s', '%s', '%s');",
+                "INSERT INTO %s ([version], [start_time], [end_time], [migration_name]) VALUES ('%s', '%s', '%s', '%s');",
                 $this->getSchemaTableName(),
                 $migration->getVersion(),
                 $startTime,
-                $endTime
+                $endTime,
+                $migration->getName()
             );
 
             $this->query($sql);

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -103,16 +103,20 @@ class Manager
             $output->writeln('-----------------------------------------');
 
             $env = $this->getEnvironment($environment);
-            $versions = $env->getVersions();
+            $versions = $env->getVersionLog();
+            $maxNameLength = max(array_map(function($version) {
+                return strlen($version['migration_name']);
+            }, $versions));
 
             foreach ($this->getMigrations() as $migration) {
-                if (in_array($migration->getVersion(), $versions)) {
+                if (array_key_exists($migration->getVersion(), $versions)) {
                     $status = '     <info>up</info> ';
-                    unset($versions[array_search($migration->getVersion(), $versions)]);
+                    unset($versions[$migration->getVersion()]);
                 } else {
                     $hasDownMigration = true;
                     $status = '   <error>down</error> ';
                 }
+                $maxNameLength = max($maxNameLength, strlen($migration->getName()));
 
                 $output->writeln(
                     $status
@@ -127,7 +131,8 @@ class Manager
                 foreach ($versions as $missing) {
                     $output->writeln(
                         '     <error>up</error> '
-                        . sprintf(' %14.0f ', $missing)
+                        . sprintf(' %14.0f ', $missing['version'])
+                        . ' <comment>'.str_pad($missing['migration_name'], $maxNameLength, ' ').'</comment> '
                         . ' <error>** MISSING **</error>'
                     );
                 }

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -104,9 +104,9 @@ class Manager
 
             $env = $this->getEnvironment($environment);
             $versions = $env->getVersionLog();
-            $maxNameLength = max(array_map(function($version) {
+            $maxNameLength = $versions ? max(array_map(function($version) {
                 return strlen($version['migration_name']);
-            }, $versions));
+            }, $versions)) : 0;
 
             foreach ($this->getMigrations() as $migration) {
                 if (array_key_exists($migration->getVersion(), $versions)) {

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -132,7 +132,7 @@ class Manager
                     $output->writeln(
                         '     <error>up</error> '
                         . sprintf(' %14.0f ', $missing['version'])
-                        . ' <comment>'.str_pad($missing['migration_name'], $maxNameLength, ' ').'</comment> '
+                        . ' <comment>' . str_pad($missing['migration_name'], $maxNameLength, ' ') . '</comment> '
                         . ' <error>** MISSING **</error>'
                     );
                 }

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -231,6 +231,16 @@ class Environment
     }
 
     /**
+     * Get all migration log entries, indexed by version number.
+     *
+     * @return array
+     */
+    public function getVersionLog()
+    {
+        return $this->getAdapter()->getVersionLog();
+    }
+
+    /**
      * Sets the current version of the environment.
      *
      * @param int $version Environment Version

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -69,8 +69,11 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->once())
-                ->method('getVersions')
-                ->will($this->returnValue(array('20120111235330', '20120116183504')));
+                ->method('getVersionLog')
+                ->will($this->returnValue([
+                    '20120111235330' => ['version' => '20120111235330', 'migration_name' => ''],
+                    '20120116183504' => ['version' => '20120815145812', 'migration_name' => '']
+                ]));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->getOutput()->setDecorated(false);
@@ -109,8 +112,11 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->once())
-                ->method('getVersions')
-                ->will($this->returnValue(array('20120103083300', '20120815145812')));
+                ->method('getVersionLog')
+                ->will($this->returnValue([
+                     '20120103083300' => ['version' => '20120103083300', 'migration_name' => ''],
+                     '20120815145812' => ['version' => '20120815145812', 'migration_name' => 'Example']
+                 ]));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->getOutput()->setDecorated(false);
@@ -119,8 +125,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertRegExp('/up  20120103083300  \*\* MISSING \*\*/', $outputStr);
-        $this->assertRegExp('/up  20120815145812  \*\* MISSING \*\*/', $outputStr);
+        $this->assertRegExp('/up  20120103083300  *\*\* MISSING \*\*/', $outputStr);
+        $this->assertRegExp('/up  20120815145812  Example *\*\* MISSING \*\*/', $outputStr);
     }
 
     public function testPrintStatusMethodWithDownMigrations()
@@ -128,8 +134,10 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->once())
-                ->method('getVersions')
-                ->will($this->returnValue(array('20120111235330')));
+                ->method('getVersionLog')
+                ->will($this->returnValue([
+                    '20120111235330' => ['version' => '20120111235330', 'migration_name' => '']
+                ]));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->getOutput()->setDecorated(false);


### PR DESCRIPTION
Resolves #543 

To reduce the time it takes to locate which branch of code contains a missing migration, all migration names are now stored in the phinxlog table. These are now used as a fall-back reference when the status command is run.

**Example**
This image shows how even though this branch doesn't currently contain a previously migrated migration, the name still shows up in the status log:
![migration-screenshot](https://cloud.githubusercontent.com/assets/1926626/12391425/92a8db3c-bddf-11e5-820a-dc50b97c9859.png)
