### PR TITLE
Assign $output before initialising the migration

### DIFF
--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -68,7 +68,7 @@ abstract class AbstractMigration implements MigrationInterface
     final public function __construct($version, OutputInterface $output = null)
     {
         $this->version = $version;
-        $this->output = $output;
+        $this->setOutput($output);
 
         $this->init();
     }

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -62,11 +62,14 @@ abstract class AbstractMigration implements MigrationInterface
     /**
      * Class Constructor.
      *
-     * @param int $version Migration Version
+     * @param int                  $version Migration Version
+     * @param OutputInterface|null $output
      */
-    final public function __construct($version)
+    final public function __construct($version, OutputInterface $output = null)
     {
         $this->version = $version;
+        $this->output = $output;
+
         $this->init();
     }
 

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -68,7 +68,9 @@ abstract class AbstractMigration implements MigrationInterface
     final public function __construct($version, OutputInterface $output = null)
     {
         $this->version = $version;
-        $this->setOutput($output);
+        if (!is_null($output)){
+            $this->setOutput($output);
+        }
 
         $this->init();
     }

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -556,7 +556,7 @@ class Manager
                     }
 
                     // instantiate it
-                    $migration = new $class($version);
+                    $migration = new $class($version, $this->getOutput());
 
                     if (!($migration instanceof AbstractMigration)) {
                         throw new \InvalidArgumentException(sprintf(
@@ -566,7 +566,6 @@ class Manager
                         ));
                     }
 
-                    $migration->setOutput($this->getOutput());
                     $versions[$version] = $migration;
                 }
             }

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -49,6 +49,19 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $migrationStub->getOutput());
     }
 
+    public function testGetOutputMethodWithInjectedOutput()
+    {
+        // stub output
+        $outputStub = $this->getMock('\Symfony\Component\Console\Output\OutputInterface', array(), array(array()));
+
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0, $outputStub));
+
+        // test methods
+        $this->assertNotNull($migrationStub->getOutput());
+        $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $migrationStub->getOutput());
+    }
+
     public function testGetName()
     {
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));


### PR DESCRIPTION
Allows the option of the initialisation phase of a migration to output
something meaningful, with appropriate styling options, if pre-conditions
for the migration aren't met in some way.