### PR TITLE
Adds support for running Seeds via the TextWrapper Class.

### DIFF
--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -147,6 +147,27 @@ class TextWrapper
     }
 
     /**
+    * Returns the output from running the "seed" command
+    * @param string $env environment name (optional)
+    * @param string $seed seed file to run (optional)
+    **/
+    public function getSeed($env = null, $seed){
+
+        $command = array(
+            'seed:run',
+            '-e' => $env ?: $this->getOption('environment'),
+        );
+
+
+        if(isset($seed)) {
+            $command += array('-s' => $seed);
+        }
+
+        return this->executeRun($command);
+    }
+
+
+    /**
      * Get option from options array
      *
      * @param  string $key

--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -163,7 +163,7 @@ class TextWrapper
             $command += array('-s' => $seed);
         }
 
-        return this->executeRun($command);
+        return $this->executeRun($command);
     }
 
 

--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -151,15 +151,14 @@ class TextWrapper
     * @param string $env environment name (optional)
     * @param string $seed seed file to run (optional)
     **/
-    public function getSeed($env = null, $seed){
+    public function getSeed($env = null, $seed = null){
 
         $command = array(
             'seed:run',
             '-e' => $env ?: $this->getOption('environment'),
         );
 
-
-        if(isset($seed)) {
+        if(!is_null($seed)) {
             $command += array('-s' => $seed);
         }
 


### PR DESCRIPTION
This change enables execution of seed files in the TextWrapper Class - enabling developers to seed a database programmatically.

Example code: (Assuming a php configuration file, and a categories seed file)
```
require 'vendor/autoload.php';
require "config.php";

$app = new Phinx\Console\PhinxApplication();
$wrap = new Phinx\Wrapper\TextWrapper($app, array("configuration"=>"phinx_conf.php","parser"=>"php"));

$execution = call_user_func([$wrap, "getSeed"], null, "Categories");

print "<pre>";
print $execution;
print "</pre>";
```