### PR TITLE
Added support for the "seed:run" command in TextWrapper

### DIFF
--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -147,6 +147,25 @@ class TextWrapper
     }
 
     /**
+     * Returns the output from running the "seed:run" command.
+     * @param  string $env environment name (optional)
+     * @param  string $seed single seed to run (optional)
+     * @return string
+     */
+    public function getSeedRun($env = null, $seed = null)
+    {
+        $command = array(
+            'seed:run',
+            '-e' => $env ?: $this->getOption('environment'),
+            '-c' => $this->getOption('configuration'),
+        );
+        if ($seed) {
+            $command += array('-s' => $seed);
+        }
+        return $this->executeRun($command);
+    }
+
+    /**
      * Get option from options array
      *
      * @param  string $key

--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -32,7 +32,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
 
 /**
- * Phinx text wrapper: a way to run `status`, `migrate`, and `rollback` commands
+ * Phinx text wrapper: a way to run `status`, `migrate`, `rollback` and `seed:run` commands
  * and get the output of the command back as plain text.
  *
  * @author Woody Gilk <woody.gilk@gmail.com>


### PR DESCRIPTION
When I was trying to get our database migrations and seeds executed from within our own web app, I noticed support for executing seeds was lacking in the default TextWrapper.

It wasn't very hard to extend the TextWrapper and write our own implementation for it, but I think it would be nice if Phinx supported this out of the box (since I can imagine more people wanting to fill their local dev environment with data after migrating). 

Tests for the original TextWrapper class were missing, so I did not write tests for this new method. It follows the conventions of this class as far as I can tell. I was doubting if I should also extend the app/web.php example file.

Feedback is welcome :)
