### PR TITLE
Use GLOB_BRACE constant only if it's available

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -516,7 +516,7 @@ class Manager
     {
         if (null === $this->migrations) {
             $config = $this->getConfig();
-            $phpFiles = glob($config->getMigrationPath() . DIRECTORY_SEPARATOR . '*.php', GLOB_BRACE);
+            $phpFiles = glob($config->getMigrationPath() . DIRECTORY_SEPARATOR . '*.php', defined('GLOB_BRACE') ? GLOB_BRACE : 0);
 
             // filter the files to only get the ones that match our naming scheme
             $fileNames = array();


### PR DESCRIPTION
Hi!

Some systems, particularly non-GNU, don't support `GLOB_BRACE` constant and migrations on those systems fail miserably. Since the feature is not critical for Phinx to work and, in fact, migration path is always set by a end-developer, I think the library should use the `GLOB_BRACE` constant only when it's available in the operating system.

This is my tiny pull request that changes this behavior and introduces a check if `GLOB_BRACE` constant is present. If not, it just passes `0` as `$flags` argument for `glob()` function.

Please merge, if you're happy with it.

Best,
Bartosz
