### PR TITLE
fix(pdo_sqlite): Handles correctly data insertions

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -829,7 +829,12 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                 if (is_numeric($value)) {
                     return $value;
                 }
-                return "'{$value}'";
+
+                if ($value === null) {
+                    return 'null';
+                }
+
+                return $this->getConnection()->quote($value);
             }, $row)) . ")";
 
         $this->execute($sql);

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -608,6 +608,12 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
                       'column2' => 3,
                   )
               )
+              ->insert(
+                  array(
+                      'column1' => '\'value4\'',
+                      'column2' => null,
+                  )
+              )
               ->save();
 
         $rows = $this->adapter->fetchAll('SELECT * FROM table1');
@@ -615,9 +621,11 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('value1', $rows[0]['column1']);
         $this->assertEquals('value2', $rows[1]['column1']);
         $this->assertEquals('value3', $rows[2]['column1']);
+        $this->assertEquals('\'value4\'', $rows[3]['column1']);
         $this->assertEquals(1, $rows[0]['column2']);
         $this->assertEquals(2, $rows[1]['column2']);
         $this->assertEquals(3, $rows[2]['column2']);
+        $this->assertEquals(null, $rows[3]['column2']);
     }
 
     public function testNullWithoutDefaultValue()


### PR DESCRIPTION
In some cases, data insertion with sqlite driver doesn't work.
- if data insertion contains a single quote, data isn't inserted in table.
- if null value is sent, data will be converted to empty string. "IS NULL" operator will not work.

I attach a migration example.

[20160330000000_sqlite_insertion_issue.txt](https://github.com/robmorgan/phinx/files/195077/20160330000000_sqlite_insertion_issue.txt)
