### PR TITLE
Provide the ability to run multiple seeds at once (in the given order)

### DIFF
--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -71,6 +71,7 @@ EOT
 
         $seed        = $input->getOption('seed');
         $environment = $input->getOption('environment');
+        $seedSet     = (strstr($seed, ',') !== false) ? explode(',', $seed) : [$seed];
 
         if (null === $environment) {
             $environment = $this->getConfig()->getDefaultEnvironment();
@@ -104,7 +105,9 @@ EOT
 
         // run the seed(ers)
         $start = microtime(true);
-        $this->getManager()->seed($environment, $seed);
+        foreach($seedSet as $seed) {
+            $this->getManager()->seed($environment, trim($seed));
+        }
         $end = microtime(true);
 
         $output->writeln('');


### PR DESCRIPTION
This PR adds in a simple update to allow for running multiple seeds at once.
Currently the seed command allows you to specify which you'd like to run with the `-s` command line flag like:
```
vendor/bin/phinx seed:run -s UserCreate
```

With this PR, multiple seeds can be defined here using a comma-separated list:
```
vendor/bin/phinx seed:run -s UserCreate,ProductCreate
```

The seeds are then run in that order (as opposed to the normal `seed:run` that just does them in the order `glob` finds them in).