### PR TITLE
"[InvalidArgumentException] The seed class "" does not exist" when trying to run all the available seeds

### DIFF
--- a/src/Phinx/Console/Command/SeedRun.php
+++ b/src/Phinx/Console/Command/SeedRun.php
@@ -71,7 +71,6 @@ EOT
 
         $seed        = $input->getOption('seed');
         $environment = $input->getOption('environment');
-        $seedSet     = (strstr($seed, ',') !== false) ? explode(',', $seed) : [$seed];
 
         if (null === $environment) {
             $environment = $this->getConfig()->getDefaultEnvironment();
@@ -103,11 +102,18 @@ EOT
             $output->writeln('<info>using table suffix</info> ' . $envOptions['table_suffix']);
         }
 
-        // run the seed(ers)
         $start = microtime(true);
-        foreach($seedSet as $seed) {
-            $this->getManager()->seed($environment, trim($seed));
+
+        if (null === $seed) {
+            // run all the seed(ers)
+            $this->getManager()->seed($environment);
+        } else {
+            // run seed(ers) specified in a comma-separated list of classes
+            foreach (explode(',', $seed) as $seed) {
+                $this->getManager()->seed($environment, trim($seed));
+            }
         }
+
         $end = microtime(true);
 
         $output->writeln('');

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -102,4 +102,38 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
         $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
         $this->assertRegExp('/using database development/', $commandTester->getDisplay());
     }
+
+    public function testExecuteMultipleSeeders()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new SeedRun());
+
+        // setup dependencies
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+
+        $command = $application->find('seed:run');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub->expects($this->exactly(3))
+            ->method('seed')->withConsecutive(
+                array($this->equalTo('development'), $this->equalTo('One')),
+                array($this->equalTo('development'), $this->equalTo('Two')),
+                array($this->equalTo('development'), $this->equalTo('Three'))
+            );
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(
+            array(
+                'command' => $command->getName(),
+                '--seed' => 'One,Two,Three'
+            ),
+            array('decorated' => false)
+        );
+
+        $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
+    }
 }

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -46,7 +46,7 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
         // mock the manager class
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
         $managerStub->expects($this->once())
-                    ->method('seed');
+                    ->method('seed')->with($this->identicalTo('development'), $this->identicalTo(null));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -116,11 +116,11 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
         // mock the manager class
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
         $managerStub->expects($this->exactly(3))
-            ->method('seed')->withConsecutive(
-                array($this->equalTo('development'), $this->equalTo('One')),
-                array($this->equalTo('development'), $this->equalTo('Two')),
-                array($this->equalTo('development'), $this->equalTo('Three'))
-            );
+                    ->method('seed')->withConsecutive(
+                        array($this->identicalTo('development'), $this->identicalTo('One')),
+                        array($this->identicalTo('development'), $this->identicalTo('Two')),
+                        array($this->identicalTo('development'), $this->identicalTo('Three'))
+                    );
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);


### PR DESCRIPTION
[This pull request](https://github.com/robmorgan/phinx/pull/821) introduces a bug that makes it impossible to run all the existing seed(ers). This one fixes it.

Surprisingly enough, the previous fix, according to the [Version History](https://github.com/robmorgan/phinx#version-history) has been included in version `0.5.4` which was never released (it's not available in [packagist](https://packagist.org/packages/robmorgan/phinx)).