### PR TITLE
Allowing configuration to be loaded form environment variables

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -79,6 +79,43 @@ class Config implements ConfigInterface
     }
 
     /**
+     * Create a new instance of the config class using environment variables.
+     *
+     * @throws \RuntimeException
+     * @return Config
+     */
+    public static function fromEnv()
+    {
+        /** Database name is required */
+        if(getenv('PHINX_DB_NAME') === false) {
+            throw new \RuntimeException('Cannot get database name from PHINX_DB_NAME environment variable');
+        }
+
+        /** @noinspection PhpIncludeInspection */
+        $configArray = array(
+            'paths' => array(
+                'migrations' => getenv('PHINX_PATHS_MIGRATIONS') ? : getcwd(),
+                'seeds' => getenv('PHINX_PATHS_SEEDS') ? : getcwd()
+            ),
+            'environments' => array(
+                'default_migration_table' => 'phinxlog',
+                'default_database' => 'environment',
+                'environment' => array(
+                    'adapter' => getenv('PHINX_DB_ADAPTER') ? : 'mysql',
+                    'host' => getenv('PHINX_DB_HOST') ? : 'localhost',
+                    'name' => getenv('PHINX_DB_NAME'),
+                    'user' => getenv('PHINX_DB_USER') ? : 'root',
+                    'pass' => getenv('PHINX_DB_PASS') ? : '',
+                    'port' => getenv('PHINX_DB_PORT') ? : '3306',
+                    'charset' => getenv('PHINX_DB_CHARSET') ? : 'utf8'
+                )
+            )
+        );
+
+        return new static($configArray);
+    }
+
+    /**
      * Create a new instance of the config class using a JSON file path.
      *
      * @param  string $configFilePath Path to the JSON File

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -218,13 +218,13 @@ abstract class AbstractCommand extends Command
      */
     protected function loadConfig(InputInterface $input, OutputInterface $output)
     {
-        $configFilePath = $this->locateConfigFile($input);
-        $output->writeln('<info>using config file</info> .' . str_replace(getcwd(), '', realpath($configFilePath)));
-
         $parser = $input->getOption('parser');
 
         // If no parser is specified try to determine the correct one from the file extension.  Defaults to YAML
         if (null === $parser) {
+            $configFilePath = $this->locateConfigFile($input);
+            $output->writeln('<info>using config file</info> .' . str_replace(getcwd(), '', realpath($configFilePath)));
+
             $extension = pathinfo($configFilePath, PATHINFO_EXTENSION);
 
             switch (strtolower($extension)) {
@@ -241,14 +241,17 @@ abstract class AbstractCommand extends Command
         }
 
         switch (strtolower($parser)) {
+            case 'env':
+                $config = Config::fromEnv();
+                break;
             case 'json':
-                $config = Config::fromJson($configFilePath);
+                $config = Config::fromJson($configFilePath ?: $this->locateConfigFile($input));
                 break;
             case 'php':
-                $config = Config::fromPhp($configFilePath);
+                $config = Config::fromPhp($configFilePath ?: $this->locateConfigFile($input));
                 break;
             case 'yaml':
-                $config = Config::fromYaml($configFilePath);
+                $config = Config::fromYaml($configFilePath ?: $this->locateConfigFile($input));
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('\'%s\' is not a valid parser.', $parser));


### PR DESCRIPTION
User story: We have one database per customer but one single software version deployed. We need to automate the migration of these bases. For this I made a multi-threaded script that executes a shell command for each database. The shell command gets database credentials from environment variables set up by the script. Generating the phinx configuration for each database in shell is cumbersome and not user friendly. So I added support for loading configuration from environment variables in phinx. Another approach would have been to add command line options but given the way phinx is designed (based on the assumption that we have a configuration file and not a configuration source), I would have needed to change a lot of things.

This is how it works now:
```
db-looper PHINX_DB_NAME=$DB_NAME PHINX_DB_USER=$DB_USER PHINX_PATHS_MIGRATIONS=. phinx -p env migrate
```

Feel free to change it if you think it's not coherent with design/patterns/naming conventions etc.

I would like to be able to add unit tests tests for this but unfortunately I have very limited time.