### PR TITLE
add use of limit to datetime, timestamp and time column types

### DIFF
--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -819,13 +819,16 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 return array('name' => 'decimal');
                 break;
             case static::PHINX_TYPE_DATETIME:
-                return array('name' => 'datetime');
+                $limits = isset($limit) ? array('limit' => $limit) : array();
+                return array('name' => 'datetime') + $limits;
                 break;
             case static::PHINX_TYPE_TIMESTAMP:
-                return array('name' => 'timestamp');
+                $limits = isset($limit) ? array('limit' => $limit) : array();
+                return array('name' => 'timestamp') + $limits;
                 break;
             case static::PHINX_TYPE_TIME:
-                return array('name' => 'time');
+                $limits = isset($limit) ? array('limit' => $limit) : array();
+                return array('name' => 'time') + $limits;
                 break;
             case static::PHINX_TYPE_DATE:
                 return array('name' => 'date');

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -997,6 +997,12 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
                             $this->adapter->getPhinxType('decimal(8,2)'));
         $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_TEXT, 'limit' => 1024, 'precision' => null),
                             $this->adapter->getPhinxType('text(1024)'));
+        $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_DATETIME, 'limit' => 6, 'precision' => null),
+                            $this->adapter->getPhinxType('datetime(6)'));
+        $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_TIMESTAMP, 'limit' => 6, 'precision' => null),
+                            $this->adapter->getPhinxType('timestamp(6)'));
+        $this->assertEquals(array('name' => MysqlAdapter::PHINX_TYPE_DATE, 'limit' => 6, 'precision' => null),
+                            $this->adapter->getPhinxType('date(6)'));
     }
 
 


### PR DESCRIPTION
add use of limit to datetime, timestamp and time column types for specifying fractional precision.

http://dev.mysql.com/doc/refman/5.7/en/fractional-seconds.html
