### PR TITLE
Add support for SQLite enums using CHECK().

### DIFF
--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -884,6 +884,8 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
                 break;
             case static::PHINX_TYPE_UUID:
                 return array('name' => 'char', 'limit' => 36);
+            case static::PHINX_TYPE_ENUM:
+                return array('name' => 'enum');
             // Geospatial database types
             // No specific data types exist in SQLite, instead all geospatial
             // functionality is handled in the client. See also: SpatiaLite.
@@ -1036,6 +1038,9 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         if (($column->getLimit() || isset($sqlType['limit'])) && $limitable) {
             $def .= '(' . ($column->getLimit() ? $column->getLimit() : $sqlType['limit']) . ')';
         }
+        if (($values = $column->getValues()) && is_array($values)) {
+            $def .= " CHECK({$column->getName()} IN ('" . implode("', '", $values) . "'))";
+        }
 
         $default = $column->getDefault();
 
@@ -1090,6 +1095,14 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         }
         $def .= ' `' . $indexName . '`';
         return $def;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnTypes()
+    {
+        return array_merge(parent::getColumnTypes(), array('enum'));
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -363,7 +363,8 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
               ->addColumn('column11', 'binary')
               ->addColumn('column12', 'boolean')
               ->addColumn('column13', 'string', array('limit' => 10))
-              ->addColumn('column15', 'integer', array('limit' => 10));
+              ->addColumn('column15', 'integer', array('limit' => 10))
+              ->addColumn('column16', 'enum', array('values' => array('a', 'b', 'c')));
         $pendingColumns = $table->getPendingColumns();
         $table->save();
         $columns = $this->adapter->getColumns('t');
@@ -618,6 +619,24 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $rows[0]['column2']);
         $this->assertEquals(2, $rows[1]['column2']);
         $this->assertEquals(3, $rows[2]['column2']);
+    }
+
+    public function testInserDataEnum()
+    {
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->addColumn('column1', 'enum', array('values' => ['a', 'b', 'c']))
+              ->addColumn('column2', 'enum', array('values' => ['a', 'b', 'c'], 'null' => true))
+              ->addColumn('column3', 'enum', array('values' => ['a', 'b', 'c'], 'default' => 'c'))
+              ->insert(array(
+                  'column1' => 'a',
+              ))
+              ->save();
+
+        $rows = $this->adapter->fetchAll('SELECT * FROM table1');
+
+        $this->assertEquals('a', $rows[0]['column1']);
+        $this->assertEquals(null, $rows[0]['column2']);
+        $this->assertEquals('c', $rows[0]['column3']);
     }
 
     public function testNullWithoutDefaultValue()


### PR DESCRIPTION
SQLite has dynamic types, and no support for ENUMs. This PR adds support for ENUMs using CHECK(). This allows us to at least ensure the data that is inserted is OK.

To give an idea of what it generates:

```sql
CREATE TABLE "node_rev" (
	`nodeID`	INTEGER  PRIMARY KEY AUTOINCREMENT,
	`nodeType`	ENUM CHECK(nodeType IN ( 'block' , 'relation' , 'parameter' , 'validation' , 'transformation' , 'model' , 'experiment' , 'image' , 'text' ))
)
```