### PR TITLE
Config File Location Feature

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6,12 +6,17 @@ Configuration
 
 When you initialize your project using the :doc:`Init Command<commands>`, Phinx
 creates a default file called ``phinx.yml`` in the root of your project directory.
-This file uses the YAML data serialization format.
+This file uses the YAML data serialization format.  This configuration file can
+also exist in different formats, namely as ``phinx.php`` or ``phinx.json``.
 
 If a ``--configuration`` command line option is given, Phinx will load the
-specified file. Otherwise, it will attempt to find ``phinx.php``, ``phinx.json`` or
-``phinx.yml`` and load the first file found. See the :doc:`Commands <commands>`
-chapter for more information.
+specified file.  If the environment variable ``PHINX_CONFIG_DIR`` exists, phinx
+will attempt to file a configuration file within the specified directory.
+Otherwise phinx will attempt to find and load the first file found from the
+current working directory or the first level of directories under the current
+working directory.
+
+See the :doc:`Commands <commands>` chapter for more information.
 
 .. warning::
 

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -186,11 +186,23 @@ abstract class AbstractCommand extends Command
 
         $cwd = getcwd();
 
+        $locateDirs = [];
+
+        if ($envDir = getenv('PHINX_CONFIG_DIR')) {
+            $locateDirs[] = $envDir;
+        }
+
+        $locateDirs[] = $cwd . DIRECTORY_SEPARATOR;
+
         // locate the phinx config file (default: phinx.yml)
-        // TODO - In future walk the tree in reverse (max 10 levels)
-        $locator = new FileLocator(array(
-            $cwd . DIRECTORY_SEPARATOR
-        ));
+        // while traversing 1 level deep (for example config/ directory)
+        foreach (scandir($cwd) as $cwdDir) {
+            if (!in_array($cwdDir, ['.', '..', 'vendor']) && is_dir($cwd . DIRECTORY_SEPARATOR . $cwdDir)) {
+                $locateDirs[] = $cwd . DIRECTORY_SEPARATOR . $cwdDir;
+            }
+        }
+
+        $locator = new FileLocator($locateDirs);
 
         if (!$useDefault) {
             // Locate() throws an exception if the file does not exist

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -190,15 +190,15 @@ abstract class AbstractCommand extends Command
 
         if ($envDir = getenv('PHINX_CONFIG_DIR')) {
             $locateDirs[] = $envDir;
-        }
+        } else {
+            $locateDirs[] = $cwd . DIRECTORY_SEPARATOR;
 
-        $locateDirs[] = $cwd . DIRECTORY_SEPARATOR;
-
-        // locate the phinx config file (default: phinx.yml)
-        // while traversing 1 level deep (for example config/ directory)
-        foreach (scandir($cwd) as $cwdDir) {
-            if (!in_array($cwdDir, ['.', '..', 'vendor']) && is_dir($cwd . DIRECTORY_SEPARATOR . $cwdDir)) {
-                $locateDirs[] = $cwd . DIRECTORY_SEPARATOR . $cwdDir;
+            // locate the phinx config file (default: phinx.{php,json,yml})
+            // while traversing 1 level deep (for example `config/` directory)
+            foreach (scandir($cwd) as $cwdDir) {
+                if (!in_array($cwdDir, ['.', '..', 'vendor']) && is_dir($cwd . DIRECTORY_SEPARATOR . $cwdDir)) {
+                    $locateDirs[] = $cwd . DIRECTORY_SEPARATOR . $cwdDir;
+                }
             }
         }
 

--- a/tests/Phinx/Console/Command/AbstractCommandTest.php
+++ b/tests/Phinx/Console/Command/AbstractCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Test\Phinx\Console\Command;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class AbstractCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFileFoundInDefaultPlace()
+    {
+        chdir(__DIR__ . '/Asset/default-test');
+        $command = new Asset\FindConfigTestCommand();
+        $foundFile = $command->callLocateConfigFile();
+        $this->assertEquals(__DIR__ . '/Asset/default-test/phinx.yml', $foundFile);
+    }
+
+    public function testFindFileInCurrentWorkingDirectory()
+    {
+        putenv('PHINX_CONFIG_DIR=' . __DIR__ . '/Asset/env-test');
+        $command = new Asset\FindConfigTestCommand();
+        $foundFile = $command->callLocateConfigFile();
+        $this->assertEquals(__DIR__ . '/Asset/env-test/phinx.php', $foundFile);
+    }
+
+    public function testFindFileInNestedConfigDirectory()
+    {
+        chdir(__DIR__ . '/Asset/app-test');
+        $command = new Asset\FindConfigTestCommand();
+        $foundFile = $command->callLocateConfigFile();
+        $this->assertEquals(__DIR__ . '/Asset/app-test/config/phinx.php', $foundFile);
+    }
+
+}

--- a/tests/Phinx/Console/Command/Asset/FindConfigTestCommand.php
+++ b/tests/Phinx/Console/Command/Asset/FindConfigTestCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Test\Phinx\Console\Command\Asset;
+
+use Phinx\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class FindConfigTestCommand extends AbstractCommand
+{
+    public function configure()
+    {
+        parent::configure();
+        $this->setName('test');
+    }
+
+    public function callLocateConfigFile()
+    {
+        $input = new ArrayInput([]);
+        $input->bind($this->getDefinition());
+        return $this->locateConfigFile($input);
+    }
+}
+

--- a/tests/Phinx/Console/Command/Asset/app-test/config/phinx.php
+++ b/tests/Phinx/Console/Command/Asset/app-test/config/phinx.php
@@ -1,0 +1,2 @@
+<?php
+// empty file

--- a/tests/Phinx/Console/Command/Asset/env-test/phinx.php
+++ b/tests/Phinx/Console/Command/Asset/env-test/phinx.php
@@ -1,0 +1,2 @@
+<?php
+// empty file


### PR DESCRIPTION
Features added:
- ability to provide PHINX_CONFIG_DIR to scan
- ability to traverse one level deep looking for matching config

Thoughts on including this?

The motivation is to allow the config files to live outside of root, but also in a discoverable place.  The idea behind the environment variable is so that isolated development environments (virtual, docker compose), can specify the migration directory (should be be more than 1 level deep).
