### PR TITLE
Introduce support for InputInterface alongside OutputInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Version History
 
-**0.6.x-dev** (****)
+**0.6-x-dev** (****)
+
+* Introduce Input and Output access to migrations and template creation
+* Backward incompatibility - see [UPGRADE_0.6](UPGRADE_0.6.md) document.
 
 **0.5.x-dev** (****)
 

--- a/UPGRADE_0.6.md
+++ b/UPGRADE_0.6.md
@@ -1,1 +1,4 @@
 # Upgrading Phinx to 0.6
+
+* Phinx 0.6 allows template creation access to the InputInterface and OutputInterface.
+    To upgrade, rather than implementing the ```\Phinx\Migration\CreationInterface``` interface in your template creation class, extend the ```\Phinx\Migration\AbstractTemplateCreation``` abstract class.

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -92,7 +92,7 @@ abstract class AbstractCommand extends Command
             $this->loadConfig($input, $output);
         }
 
-        $this->loadManager($output);
+        $this->loadManager($input, $output);
         // report the paths
         $output->writeln('<info>using migration path</info> ' . $this->getConfig()->getMigrationPath());
         try {
@@ -262,13 +262,13 @@ abstract class AbstractCommand extends Command
     /**
      * Load the migrations manager and inject the config
      *
+     * @param InputInterface $input
      * @param OutputInterface $output
-     * @return void
      */
-    protected function loadManager(OutputInterface $output)
+    protected function loadManager(InputInterface $input, OutputInterface $output)
     {
         if (null === $this->getManager()) {
-            $manager = new Manager($this->getConfig(), $output);
+            $manager = new Manager($this->getConfig(), $input, $output);
             $this->setManager($manager);
         }
     }

--- a/src/Phinx/Console/Command/Test.php
+++ b/src/Phinx/Console/Command/Test.php
@@ -72,7 +72,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->loadConfig($input, $output);
-        $this->loadManager($output);
+        $this->loadManager($input, $output);
 
         $this->verifyMigrationDirectory($this->getConfig()->getMigrationPath());
 

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -28,6 +28,7 @@
  */
 namespace Phinx\Db\Adapter;
 
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
@@ -116,6 +117,21 @@ interface AdapterInterface
      * @return mixed
      */
     public function getOption($name);
+
+    /**
+     * Sets the console input.
+     *
+     * @param InputInterface $input Input
+     * @return AdapterInterface
+     */
+    public function setInput(InputInterface $input);
+
+    /**
+     * Gets the console input.
+     *
+     * @return InputInterface
+     */
+    public function getInput();
 
     /**
      * Sets the console output.

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -33,6 +33,7 @@ use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Index;
 use Phinx\Db\Table\ForeignKey;
 use Phinx\Migration\MigrationInterface;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -106,6 +107,23 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     public function getOption($name)
     {
         return $this->adapter->getOption($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->adapter->setInput($input);
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInput()
+    {
+        return $this->adapter->getInput();
     }
 
     /**

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -28,6 +28,7 @@
  */
 namespace Phinx\Db\Adapter;
 
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Phinx\Db\Table;
@@ -45,6 +46,11 @@ abstract class PdoAdapter implements AdapterInterface
      * @var array
      */
     protected $options = array();
+
+    /**
+     * @var InputInterface
+     */
+    protected $input;
 
     /**
      * @var OutputInterface
@@ -70,11 +76,15 @@ abstract class PdoAdapter implements AdapterInterface
      * Class Constructor.
      *
      * @param array $options Options
+     * @param InputInterface $input Input Interface
      * @param OutputInterface $output Output Interface
      */
-    public function __construct(array $options, OutputInterface $output = null)
+    public function __construct(array $options, InputInterface $input = null, OutputInterface $output = null)
     {
         $this->setOptions($options);
+        if (null !== $input) {
+            $this->setInput($input);
+        }
         if (null !== $output) {
             $this->setOutput($output);
         }
@@ -123,6 +133,23 @@ abstract class PdoAdapter implements AdapterInterface
             return null;
         }
         return $this->options[$name];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInput()
+    {
+        return $this->input;
     }
 
     /**
@@ -185,7 +212,7 @@ abstract class PdoAdapter implements AdapterInterface
             $table = new Table($this->getSchemaTableName(), array(), $this);
             if (!$table->hasColumn('migration_name')) {
                 $table
-                    ->addColumn('migration_name', 'string', 
+                    ->addColumn('migration_name', 'string',
                         array('limit' => 100, 'after' => 'version', 'default' => null, 'null' => true)
                     )
                     ->save();

--- a/src/Phinx/Migration/AbstractMigration.php
+++ b/src/Phinx/Migration/AbstractMigration.php
@@ -30,6 +30,7 @@ namespace Phinx\Migration;
 
 use Phinx\Db\Table;
 use Phinx\Db\Adapter\AdapterInterface;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -60,13 +61,27 @@ abstract class AbstractMigration implements MigrationInterface
     protected $output;
 
     /**
+     * @var InputInterface
+     */
+    protected $input;
+
+    /**
      * Class Constructor.
      *
      * @param int $version Migration Version
+     * @param InputInterface|null $input
+     * @param OutputInterface|null $output
      */
-    final public function __construct($version)
+    final public function __construct($version, InputInterface $input = null, OutputInterface $output = null)
     {
         $this->version = $version;
+        if (!is_null($input)){
+            $this->setInput($input);
+        }
+        if (!is_null($output)){
+            $this->setOutput($output);
+        }
+
         $this->init();
     }
 
@@ -108,6 +123,23 @@ abstract class AbstractMigration implements MigrationInterface
     public function getAdapter()
     {
         return $this->adapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInput()
+    {
+        return $this->input;
     }
 
     /**

--- a/src/Phinx/Migration/AbstractTemplateCreation.php
+++ b/src/Phinx/Migration/AbstractTemplateCreation.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @package    Phinx
+ * @subpackage Phinx\Migration
+ */
+namespace Phinx\Migration;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractTemplateCreation implements CreationInterface
+{
+    /**
+     * @var InputInterface
+     */
+    protected $input;
+
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
+
+    /**
+     * Class Constructor.
+     *
+     * @param InputInterface|null  $input
+     * @param OutputInterface|null $output
+     */
+    public function __construct(InputInterface $input = null, OutputInterface $output = null)
+    {
+        if (!is_null($input)) {
+            $this->setInput($input);
+        }
+        if (!is_null($output)) {
+            $this->setOutput($output);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInput()
+    {
+        return $this->input;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOutput()
+    {
+        return $this->output;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOutput(OutputInterface $output)
+    {
+        $this->output = $output;
+
+        return $this;
+    }
+}

--- a/src/Phinx/Migration/CreationInterface.php
+++ b/src/Phinx/Migration/CreationInterface.php
@@ -28,6 +28,9 @@
  */
 namespace Phinx\Migration;
 
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
 /**
  * Migration interface
  *
@@ -35,6 +38,38 @@ namespace Phinx\Migration;
  */
 interface CreationInterface
 {
+    /**
+     * CreationInterface constructor.
+     *
+     * @param InputInterface|null  $input
+     * @param OutputInterface|null $output
+     */
+    public function __construct(InputInterface $input = null, OutputInterface $output = null);
+
+    /**
+     * @param InputInterface $input
+     *
+     * @return CreationInterface
+     */
+    public function setInput(InputInterface $input);
+
+    /**
+     * @param OutputInterface $output
+     *
+     * @return CreationInterface
+     */
+    public function setOutput(OutputInterface $output);
+
+    /**
+     * @return InputInterface
+     */
+    public function getInput();
+
+    /**
+     * @return OutputInterface
+     */
+    public function getOutput();
+
     /**
      * Get the migration template.
      *

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -28,6 +28,7 @@
  */
 namespace Phinx\Migration;
 
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Phinx\Config\ConfigInterface;
 use Phinx\Migration\Manager\Environment;
@@ -41,6 +42,11 @@ class Manager
      * @var ConfigInterface
      */
     protected $config;
+
+    /**
+     * @var InputInterface
+     */
+    protected $input;
 
     /**
      * @var OutputInterface
@@ -76,11 +82,13 @@ class Manager
      * Class Constructor.
      *
      * @param ConfigInterface $config Configuration Object
+     * @param InputInterface $input Console Input
      * @param OutputInterface $output Console Output
      */
-    public function __construct(ConfigInterface $config, OutputInterface $output)
+    public function __construct(ConfigInterface $config, InputInterface $input, OutputInterface $output)
     {
         $this->setConfig($config);
+        $this->setInput($input);
         $this->setOutput($output);
     }
 
@@ -473,6 +481,28 @@ class Manager
     }
 
     /**
+     * Sets the console input.
+     *
+     * @param InputInterface $input Input
+     * @return Manager
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+        return $this;
+    }
+
+    /**
+     * Gets the console input.
+     *
+     * @return InputInterface
+     */
+    public function getInput()
+    {
+        return $this->input;
+    }
+
+    /**
      * Sets the console output.
      *
      * @param OutputInterface $output Output
@@ -556,7 +586,7 @@ class Manager
                     }
 
                     // instantiate it
-                    $migration = new $class($version);
+                    $migration = new $class($version, $this->getInput(), $this->getOutput());
 
                     if (!($migration instanceof AbstractMigration)) {
                         throw new \InvalidArgumentException(sprintf(
@@ -566,7 +596,6 @@ class Manager
                         ));
                     }
 
-                    $migration->setOutput($this->getOutput());
                     $versions[$version] = $migration;
                 }
             }
@@ -625,7 +654,7 @@ class Manager
                     }
 
                     // instantiate it
-                    $seed = new $class();
+                    $seed = new $class($this->getInput(), $this->getOutput());
 
                     if (!($seed instanceof AbstractSeed)) {
                         throw new \InvalidArgumentException(sprintf(
@@ -635,7 +664,6 @@ class Manager
                         ));
                     }
 
-                    $seed->setOutput($this->getOutput());
                     $seeds[$class] = $seed;
                 }
             }

--- a/src/Phinx/Migration/MigrationInterface.php
+++ b/src/Phinx/Migration/MigrationInterface.php
@@ -30,6 +30,7 @@ namespace Phinx\Migration;
 
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -82,6 +83,21 @@ interface MigrationInterface
      * @return AdapterInterface
      */
     public function getAdapter();
+
+    /**
+     * Sets the input object to be used in migration object
+     *
+     * @param InputInterface $input
+     * @return MigrationInterface
+     */
+    public function setInput(InputInterface $input);
+
+    /**
+     * Gets the input object to be used in migration object
+     *
+     * @return InputInterface
+     */
+    public function getInput();
 
     /**
      * Sets the output object to be used in migration object

--- a/src/Phinx/Seed/AbstractSeed.php
+++ b/src/Phinx/Seed/AbstractSeed.php
@@ -30,6 +30,7 @@ namespace Phinx\Seed;
 
 use Phinx\Db\Table;
 use Phinx\Db\Adapter\AdapterInterface;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -50,6 +51,11 @@ abstract class AbstractSeed implements SeedInterface
     protected $adapter;
 
     /**
+     * @var InputInterface
+     */
+    protected $input;
+
+    /**
      * @var OutputInterface
      */
     protected $output;
@@ -57,10 +63,18 @@ abstract class AbstractSeed implements SeedInterface
     /**
      * Class Constructor.
      *
-     * @return void
+     * @param InputInterface $input
+     * @param OutputInterface $output
      */
-    final public function __construct()
+    final public function __construct(InputInterface $input = null, OutputInterface $output = null)
     {
+        if (!is_null($input)){
+            $this->setInput($input);
+        }
+        if (!is_null($output)){
+            $this->setOutput($output);
+        }
+        
         $this->init();
     }
 
@@ -95,6 +109,23 @@ abstract class AbstractSeed implements SeedInterface
     public function getAdapter()
     {
         return $this->adapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInput()
+    {
+        return $this->input;
     }
 
     /**

--- a/src/Phinx/Seed/SeedInterface.php
+++ b/src/Phinx/Seed/SeedInterface.php
@@ -30,6 +30,7 @@ namespace Phinx\Seed;
 
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -65,6 +66,21 @@ interface SeedInterface
      * @return AdapterInterface
      */
     public function getAdapter();
+
+    /**
+     * Sets the input object to be used in migration object
+     *
+     * @param InputInterface $input
+     * @return MigrationInterface
+     */
+    public function setInput(InputInterface $input);
+
+    /**
+     * Gets the input object to be used in migration object
+     *
+     * @return InputInterface
+     */
+    public function getInput();
 
     /**
      * Sets the output object to be used in migration object

--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -7,6 +7,9 @@ use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\Create;
 use Phinx\Console\PhinxApplication;
 use Phinx\Migration\Manager;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -21,6 +24,16 @@ class CreateTest extends \PHPUnit_Framework_TestCase
      * @var ConfigInterface|array
      */
     protected $config = array();
+
+    /**
+     * @var InputInterface $input
+     */
+    protected $input;
+
+    /**
+     * @var OutputInterface $output
+     */
+    protected $output;
 
     protected function setUp()
     {
@@ -48,6 +61,9 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         foreach (glob($this->config->getMigrationPath().'/*.*') as $migration) {
             unlink($migration);
         }
+
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
     /**
@@ -59,14 +75,11 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
         /** @var Create $command $command */
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -87,14 +100,11 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
         /** @var Create $command $command */
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -112,14 +122,11 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
         /** @var Create $command $command */
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
 
         $this->config['templates'] = array(
             'file' => 'MyTemplate',
@@ -175,14 +182,11 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
         /** @var Create $command $command */
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
 
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;
@@ -240,14 +244,11 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
         /** @var Create $command $command */
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
 
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;
@@ -304,14 +305,11 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $application = new PhinxApplication('testing');
         $application->add(new Create());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
         /** @var Create $command $command */
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
 
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;

--- a/tests/Phinx/Console/Command/InitTest.php
+++ b/tests/Phinx/Console/Command/InitTest.php
@@ -2,9 +2,9 @@
 
 namespace Test\Phinx\Console\Command;
 
-use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Console\Output\StreamOutput;
 use Phinx\Console\Command\Init;
+use Phinx\Console\PhinxApplication;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class InitTest extends \PHPUnit_Framework_TestCase
 {
@@ -18,11 +18,8 @@ class InitTest extends \PHPUnit_Framework_TestCase
 
     public function testConfigIsWritten()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Init());
-
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
 
         $command = $application->find('init');
 
@@ -52,11 +49,8 @@ class InitTest extends \PHPUnit_Framework_TestCase
     public function testThrowsExceptionWhenConfigFilePresent()
     {
         touch(sys_get_temp_dir() . '/phinx.yml');
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Init());
-
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
 
         $command = $application->find('init');
 

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -2,14 +2,34 @@
 
 namespace Test\Phinx\Console\Command;
 
-use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Console\Output\StreamOutput;
 use Phinx\Config\Config;
+use Phinx\Config\ConfigInterface;
 use Phinx\Console\Command\Migrate;
+use Phinx\Console\PhinxApplication;
+use Phinx\Migration\Manager;
+use PHPUnit_Framework_MockObject_MockObject;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class MigrateTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ConfigInterface|array
+     */
     protected $config = array();
+
+    /**
+     * @var InputInterface $input
+     */
+    protected $input;
+
+    /**
+     * @var OutputInterface $output
+     */
+    protected $output;
 
     protected function setUp()
     {
@@ -30,20 +50,22 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
                 )
             )
         ));
+
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
     public function testExecute()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Migrate());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var Migrate $command */
         $command = $application->find('migrate');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $this->input, $this->output]);
         $managerStub->expects($this->once())
                     ->method('migrate');
 
@@ -59,16 +81,15 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
     public function testExecuteWithEnvironmentOption()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Migrate());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var Migrate $command */
         $command = $application->find('migrate');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $this->input, $this->output]);
         $managerStub->expects($this->any())
                     ->method('migrate');
 
@@ -84,16 +105,15 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
     public function testDatabaseNameSpecified()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Migrate());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var Migrate $command */
         $command = $application->find('migrate');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $this->input, $this->output]);
         $managerStub->expects($this->once())
                     ->method('migrate');
 

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -2,6 +2,13 @@
 
 namespace Test\Phinx\Console\Command;
 
+use Phinx\Config\ConfigInterface;
+use Phinx\Console\PhinxApplication;
+use Phinx\Migration\Manager;
+use PHPUnit_Framework_MockObject_MockObject;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\StreamOutput;
 use Phinx\Config\Config;
@@ -9,7 +16,20 @@ use Phinx\Console\Command\Rollback;
 
 class RollbackTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ConfigInterface|array
+     */
     protected $config = array();
+
+    /**
+     * @var InputInterface $input
+     */
+    protected $input;
+
+    /**
+     * @var OutputInterface $output
+     */
+    protected $output;
 
     protected function setUp()
     {
@@ -30,20 +50,22 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
                 )
             )
         ));
+
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
     public function testExecute()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Rollback());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var Rollback $command */
         $command = $application->find('rollback');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('rollback');
 
@@ -58,16 +80,15 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
     public function testExecuteWithEnvironmentOption()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Rollback());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var Rollback $command */
         $command = $application->find('rollback');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('rollback');
 
@@ -81,16 +102,15 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
     public function testDatabaseNameSpecified()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Rollback());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var Rollback $command */
         $command = $application->find('rollback');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('rollback');
 

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -2,6 +2,13 @@
 
 namespace Test\Phinx\Console\Command;
 
+use Phinx\Config\ConfigInterface;
+use Phinx\Console\PhinxApplication;
+use Phinx\Migration\Manager;
+use PHPUnit_Framework_MockObject_MockObject;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\StreamOutput;
 use Phinx\Config\Config;
@@ -9,7 +16,20 @@ use Phinx\Console\Command\SeedCreate;
 
 class SeedCreateTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ConfigInterface|array
+     */
     protected $config = array();
+
+    /**
+     * @var InputInterface $input
+     */
+    protected $input;
+
+    /**
+     * @var OutputInterface $output
+     */
+    protected $output;
 
     protected function setUp()
     {
@@ -31,6 +51,9 @@ class SeedCreateTest extends \PHPUnit_Framework_TestCase
                 )
             )
         ));
+
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
     /**
@@ -39,16 +62,15 @@ class SeedCreateTest extends \PHPUnit_Framework_TestCase
      */
     public function testExecute()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new SeedCreate());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var SeedCreate $command */
         $command = $application->find('seed:create');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -64,16 +86,15 @@ class SeedCreateTest extends \PHPUnit_Framework_TestCase
      */
     public function testExecuteWithInvalidClassName()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new SeedCreate());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var SeedCreate $command */
         $command = $application->find('seed:create');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -2,6 +2,13 @@
 
 namespace Test\Phinx\Console\Command;
 
+use Phinx\Config\ConfigInterface;
+use Phinx\Console\PhinxApplication;
+use Phinx\Migration\Manager;
+use PHPUnit_Framework_MockObject_MockObject;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\StreamOutput;
 use Phinx\Config\Config;
@@ -9,7 +16,20 @@ use Phinx\Console\Command\SeedRun;
 
 class SeedRunTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ConfigInterface|array
+     */
     protected $config = array();
+
+    /**
+     * @var InputInterface $input
+     */
+    protected $input;
+
+    /**
+     * @var OutputInterface $output
+     */
+    protected $output;
 
     protected function setUp()
     {
@@ -31,20 +51,22 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
                 )
             )
         ));
+
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
     public function testExecute()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new SeedRun());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var SeedRun $command */
         $command = $application->find('seed:run');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('seed')->with($this->identicalTo('development'), $this->identicalTo(null));
 
@@ -59,16 +81,15 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
     public function testExecuteWithEnvironmentOption()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new SeedRun());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var SeedRun $command */
         $command = $application->find('seed:run');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->any())
                     ->method('migrate');
 
@@ -82,16 +103,15 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
     public function testDatabaseNameSpecified()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new SeedRun());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var SeedRun $command */
         $command = $application->find('seed:run');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('seed');
 
@@ -105,16 +125,15 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
     public function testExecuteMultipleSeeders()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new SeedRun());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var SeedRun $command */
         $command = $application->find('seed:run');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->exactly(3))
                     ->method('seed')->withConsecutive(
                         array($this->identicalTo('development'), $this->identicalTo('One')),

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -2,6 +2,13 @@
 
 namespace Test\Phinx\Console\Command;
 
+use Phinx\Config\ConfigInterface;
+use Phinx\Console\PhinxApplication;
+use Phinx\Migration\Manager;
+use PHPUnit_Framework_MockObject_MockObject;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\StreamOutput;
 use Phinx\Config\Config;
@@ -9,7 +16,20 @@ use Phinx\Console\Command\Status;
 
 class StatusTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ConfigInterface|array
+     */
     protected $config = array();
+
+    /**
+     * @var InputInterface $input
+     */
+    protected $input;
+
+    /**
+     * @var OutputInterface $output
+     */
+    protected $output;
 
     protected function setUp()
     {
@@ -30,20 +50,22 @@ class StatusTest extends \PHPUnit_Framework_TestCase
                 )
             )
         ));
+
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
     }
 
     public function testExecute()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Status());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var Status $command */
         $command = $application->find('status');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('printStatus')
                     ->will($this->returnValue(0));
@@ -60,16 +82,15 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
     public function testExecuteWithEnvironmentOption()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Status());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var Status $command */
         $command = $application->find('status');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('printStatus')
                     ->will($this->returnValue(0));
@@ -85,16 +106,15 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatSpecified()
     {
-        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application = new PhinxApplication('testing');
         $application->add(new Status());
 
-        // setup dependencies
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-
+        /** @var Status $command */
         $command = $application->find('status');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $output));
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('printStatus')
                     ->will($this->returnValue(0));

--- a/tests/Phinx/Console/Command/TemplateGenerators/NullGenerator.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/NullGenerator.php
@@ -1,9 +1,9 @@
 <?php
 namespace Test\Phinx\Console\Command\TemplateGenerators;
 
-use Phinx\Migration\CreationInterface;
+use Phinx\Migration\AbstractTemplateCreation;
 
-class NullGenerator implements CreationInterface
+class NullGenerator extends AbstractTemplateCreation
 {
     /**
      * Get the migration template.

--- a/tests/Phinx/Console/Command/TemplateGenerators/SimpleGenerator.php
+++ b/tests/Phinx/Console/Command/TemplateGenerators/SimpleGenerator.php
@@ -1,9 +1,9 @@
 <?php
 namespace Test\Phinx\Console\Command\TemplateGenerators;
 
-use Phinx\Migration\CreationInterface;
+use Phinx\Migration\AbstractTemplateCreation;
 
-class SimpleGenerator implements CreationInterface
+class SimpleGenerator extends AbstractTemplateCreation
 {
     /**
      * Get the migration template.

--- a/tests/Phinx/Console/PhinxApplicationTest.php
+++ b/tests/Phinx/Console/PhinxApplicationTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Console;
 
+use Phinx\Console\Command\AbstractCommand;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use Phinx\Console\PhinxApplication;
 
@@ -9,10 +10,13 @@ class PhinxApplicationTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider provider
+     *
+     * @param AbstractCommand $command
+     * @param $result
      */
     public function testRun($command, $result)
     {
-        $app = new \Phinx\Console\PhinxApplication('testing');
+        $app = new PhinxApplication('testing');
         $app->setAutoExit(false); // Set autoExit to false when testing
         $app->setCatchExceptions(false);
 

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -7,7 +7,7 @@ use Phinx\Db\Adapter\AdapterFactory;
 class AdapterFactoryTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var Phinx\Db\Adapter\AdapterFactory
+     * @var \Phinx\Db\Adapter\AdapterFactory
      */
     private $factory;
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Db\Adapter;
 
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Phinx\Db\Adapter\MysqlAdapter;
 
@@ -25,7 +26,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
             'pass' => TESTS_PHINX_DB_ADAPTER_MYSQL_PASSWORD,
             'port' => TESTS_PHINX_DB_ADAPTER_MYSQL_PORT
         );
-        $this->adapter = new MysqlAdapter($options, new NullOutput());
+        $this->adapter = new MysqlAdapter($options, new ArrayInput([]), new NullOutput());
 
         // ensure the database is empty for each test
         $this->adapter->dropDatabase($options['name']);
@@ -64,7 +65,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         );
 
         try {
-            $adapter = new MysqlAdapter($options, new NullOutput());
+            $adapter = new MysqlAdapter($options, new ArrayInput([]), new NullOutput());
             $adapter->connect();
             $this->fail('Expected the adapter to throw an exception');
         } catch (\InvalidArgumentException $e) {
@@ -90,7 +91,7 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
             'unix_socket' => TESTS_PHINX_DB_ADAPTER_MYSQL_UNIX_SOCKET,
         );
 
-        $adapter = new MysqlAdapter($options, new NullOutput());
+        $adapter = new MysqlAdapter($options, new ArrayInput([]), new NullOutput());
         $adapter->connect();
 
         $this->assertInstanceOf('\PDO', $this->adapter->getConnection());

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Db\Adapter;
 
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Index;
@@ -62,7 +63,7 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Mysql tests disabled. See TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED constant.');
         }
 
-        $this->adapter = new MysqlAdapterTester(array(), new NullOutput());
+        $this->adapter = new MysqlAdapterTester(array(), new ArrayInput([]), new NullOutput());
 
         $this->conn = $this->getMockBuilder('PDOMock')
                            ->disableOriginalConstructor()

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Db\Adapter;
 
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Phinx\Db\Adapter\PostgresAdapter;
 
@@ -46,7 +47,7 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
             'port' => TESTS_PHINX_DB_ADAPTER_POSTGRES_PORT,
             'schema' => TESTS_PHINX_DB_ADAPTER_POSTGRES_DATABASE_SCHEMA
         );
-        $this->adapter = new PostgresAdapter($options, new NullOutput());
+        $this->adapter = new PostgresAdapter($options, new ArrayInput([]), new NullOutput());
 
         $this->adapter->dropAllSchemas();
         $this->adapter->createSchema($options['schema']);
@@ -87,7 +88,7 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         );
 
         try {
-            $adapter = new PostgresAdapter($options, new NullOutput());
+            $adapter = new PostgresAdapter($options, new ArrayInput([]), new NullOutput());
             $adapter->connect();
             $this->fail('Expected the adapter to throw an exception');
         } catch (\InvalidArgumentException $e) {

--- a/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SQLiteAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Db\Adapter;
 
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Phinx\Db\Adapter\SQLiteAdapter;
 
@@ -21,7 +22,7 @@ class SQLiteAdapterTest extends \PHPUnit_Framework_TestCase
         $options = array(
             'name' => TESTS_PHINX_DB_ADAPTER_SQLITE_DATABASE
         );
-        $this->adapter = new SQLiteAdapter($options, new NullOutput());
+        $this->adapter = new SQLiteAdapter($options, new ArrayInput([]), new NullOutput());
 
         // ensure the database is empty for each test
         $this->adapter->dropDatabase($options['name']);

--- a/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/SqlServerAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Phinx\Db\Adapter;
 
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Phinx\Db\Adapter\SqlServerAdapter;
 
@@ -25,7 +26,7 @@ class SqlServerAdapterTest extends \PHPUnit_Framework_TestCase
             'pass' => TESTS_PHINX_DB_ADAPTER_SQLSRV_PASSWORD,
             'port' => TESTS_PHINX_DB_ADAPTER_SQLSRV_PORT
         );
-        $this->adapter = new SqlServerAdapter($options, new NullOutput());
+        $this->adapter = new SqlServerAdapter($options, new ArrayInput([]), new NullOutput());
 
         // ensure the database is empty for each test
         $this->adapter->dropDatabase($options['name']);
@@ -64,7 +65,7 @@ class SqlServerAdapterTest extends \PHPUnit_Framework_TestCase
         );
 
         try {
-            $adapter = new SqlServerAdapter($options, new NullOutput());
+            $adapter = new SqlServerAdapter($options, new ArrayInput([]), new NullOutput());
             $adapter->connect();
             $this->fail('Expected the adapter to throw an exception');
         } catch (\InvalidArgumentException $e) {

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -49,6 +49,32 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $migrationStub->getOutput());
     }
 
+    public function testGetInputMethodWithInjectedInput()
+    {
+        // stub input
+        $inputStub = $this->getMock('\Symfony\Component\Console\Input\InputInterface', array(), array(array()));
+
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0, $inputStub, null));
+
+        // test methods
+        $this->assertNotNull($migrationStub->getInput());
+        $this->assertInstanceOf('\Symfony\Component\Console\Input\InputInterface', $migrationStub->getInput());
+    }
+
+    public function testGetOutputMethodWithInjectedOutput()
+    {
+        // stub output
+        $outputStub = $this->getMock('\Symfony\Component\Console\Output\OutputInterface', array(), array(array()));
+
+        // stub migration
+        $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0, null, $outputStub));
+
+        // test methods
+        $this->assertNotNull($migrationStub->getOutput());
+        $this->assertInstanceOf('\Symfony\Component\Console\Output\OutputInterface', $migrationStub->getOutput());
+    }
+
     public function testGetName()
     {
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));


### PR DESCRIPTION
This commit contains a backward incompatibility for template creation classes.
Upgrade notes exist in UPGRADE_0.6.md