### PR TITLE
Introduce breakpoint support for rollbacks

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -6,6 +6,33 @@ Commands
 
 Phinx is run using a number of commands.
 
+The Breakpoint Command
+----------------------
+
+The Breakpoint command is used to set breakpoints, allowing you to limit
+rollbacks. You can toggle the breakpoint of the most recent migration by
+not supplying any parameters.
+
+.. code-block:: bash
+
+        $ phinx breakpoint -e development
+
+To toggle a breakpoint on a specific version then use the ``--target``
+parameter or ``-t`` for short.
+
+.. code-block:: bash
+
+        $ phinx breakpoint -e development -t 20120103083322
+
+You can remove all the breakpoints by using the ``--remove-all`` parameter
+or ``-r`` for short.
+
+.. code-block:: bash
+
+        $ phinx breakpoint -e development -r
+
+Breakpoints are visible when you run the ``status`` command.
+
 The Create Command
 ------------------
 

--- a/src/Phinx/Console/PhinxApplication.php
+++ b/src/Phinx/Console/PhinxApplication.php
@@ -57,6 +57,7 @@ class PhinxApplication extends Application
             new Command\Migrate(),
             new Command\Rollback(),
             new Command\Status(),
+            new Command\Breakpoint(),
             new Command\Test(),
             new Command\SeedCreate(),
             new Command\SeedRun(),

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -160,6 +160,22 @@ interface AdapterInterface
     public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime);
 
     /**
+     * Toggle a migration breakpoint.
+     *
+     * @param MigrationInterface $migration
+     *
+     * @return AdapterInterface
+     */
+    public function toggleBreakpoint(MigrationInterface $migration);
+
+    /**
+     * Reset all migration breakpoints.
+     *
+     * @return int The number of breakpoints reset
+     */
+    public function resetAllBreakpoints();
+
+    /**
      * Does the schema table exist?
      *
      * @deprecated use hasTable instead.

--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -225,6 +225,23 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     }
 
     /**
+     * @inheritDoc
+     */
+    public function toggleBreakpoint(MigrationInterface $migration)
+    {
+        $this->getAdapter()->toggleBreakpoint($migration);
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resetAllBreakpoints()
+    {
+        return $this->getAdapter()->resetAllBreakpoints();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function hasSchemaTable()

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1053,7 +1053,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(
-                "INSERT INTO %s (version, migration_name, start_time, end_time) VALUES ('%s', '%s', '%s', '%s');",
+                "INSERT INTO %s (version, migration_name, start_time, end_time, breakpoint) VALUES ('%s', '%s', '%s', '%s', 0);",
                 $this->getSchemaTableName(),
                 $migration->getVersion(),
                 substr($migration->getName(), 0, 100),

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1172,7 +1172,7 @@ SQL;
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(
-                "INSERT INTO %s ([version], [migration_name], [start_time], [end_time]) VALUES ('%s', '%s', '%s', '%s');",
+                "INSERT INTO %s ([version], [migration_name], [start_time], [end_time], [breakpoint]) VALUES ('%s', '%s', '%s', '%s', 0);",
                 $this->getSchemaTableName(),
                 $migration->getVersion(),
                 substr($migration->getName(), 0, 100),

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -132,6 +132,11 @@ class Manager
                     '%s %14.0f  %19s  %19s  <comment>%s</comment>',
                     $status, $migration->getVersion(), $version['start_time'], $version['end_time'], $migration->getName()
                 ));
+
+                if ($version && $version['breakpoint']){
+                    $output->writeln('         <error>BREAKPOINT SET</error>');
+                }
+
                 $migrations[] = array('migration_status' => trim(strip_tags($status)), 'migration_id' => sprintf('%14.0f', $migration->getVersion()), 'migration_name' => $migration->getName());
                 unset($versions[$migration->getVersion()]);
             }
@@ -143,6 +148,10 @@ class Manager
                         '     <error>up</error>  %14.0f  %19s  %19s  <comment>%s</comment>  <error>** MISSING **</error>',
                         $missing, $version['start_time'], $version['end_time'], str_pad($version['migration_name'], $maxNameLength, ' ')
                     ));
+
+                    if ($version && $version['breakpoint']){
+                        $output->writeln('         <error>BREAKPOINT SET</error>');
+                    }
                 }
             }
         } else {
@@ -206,10 +215,11 @@ class Manager
      *
      * @param string    $environment Environment
      * @param \DateTime $dateTime    Date to roll back to
+     * @param bool $force
      *
      * @return void
      */
-    public function rollbackToDateTime($environment, \DateTime $dateTime)
+    public function rollbackToDateTime($environment, \DateTime $dateTime, $force = false)
     {
         $env        = $this->getEnvironment($environment);
         $versions   = $env->getVersions();
@@ -232,7 +242,7 @@ class Manager
                 $this->getOutput()->writeln('Rolling back to version ' . $earlierVersion);
                 $migration = $earlierVersion;
             }
-            $this->rollback($environment, $migration);
+            $this->rollback($environment, $migration, $force);
         }
     }
 
@@ -359,13 +369,14 @@ class Manager
      *
      * @param string $environment Environment
      * @param int $version
+     * @param bool $force
      * @return void
      */
-    public function rollback($environment, $version = null)
+    public function rollback($environment, $version = null, $force = false)
     {
         $migrations = $this->getMigrations();
-        $env = $this->getEnvironment($environment);
-        $versions = $env->getVersions();
+        $versionLog = $this->getEnvironment($environment)->getVersionLog();
+        $versions = array_keys($versionLog);
 
         ksort($migrations);
         sort($versions);
@@ -380,10 +391,10 @@ class Manager
         if (null === $version) {
             // Get the migration before the last run migration
             $prev = count($versions) - 2;
-            $version = $prev >= 0 ? $versions[$prev] : 0;
+            $version =  0 == $prev ? 0 : $versions[$prev];
         } else {
             // Get the first migration number
-            $first = reset($versions);
+            $first = $versions[0];
 
             // If the target version is before the first migration, revert all migrations
             if ($version < $first) {
@@ -405,6 +416,10 @@ class Manager
             }
 
             if (in_array($migration->getVersion(), $versions)) {
+                if (isset($versionLog[$migration->getVersion()]) && 0 != $versionLog[$migration->getVersion()]['breakpoint'] && !$force){
+                    $this->getOutput()->writeln('<error>Breakpoint reached. Further rollbacks inhibited.</error>');
+                    break;
+                }
                 $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
             }
         }
@@ -695,5 +710,59 @@ class Manager
     public function getConfig()
     {
         return $this->config;
+    }
+
+    /**
+     * Toggles the breakpoint for a specific version.
+     *
+     * @param string $environment
+     * @param int $version
+     * @return void
+     */
+    public function toggleBreakpoint($environment, $version){
+        $migrations = $this->getMigrations();
+        $this->getMigrations();
+        $env = $this->getEnvironment($environment);
+        $versions = $env->getVersionLog();
+
+        if (empty($versions) || empty($migrations)) {
+            return;
+        }
+
+        if (null === $version) {
+            $lastVersion = end($versions);
+            $version = $lastVersion['version'];
+        }
+
+        if (0 != $version && !isset($migrations[$version])) {
+            $this->output->writeln(sprintf(
+                '<comment>warning</comment> %s is not a valid version',
+                $version
+            ));
+            return;
+        }
+
+        $env->getAdapter()->toggleBreakpoint($migrations[$version]);
+
+        $versions = $env->getVersionLog();
+
+        $this->getOutput()->writeln(
+            ' Breakpoint ' . ($versions[$version]['breakpoint'] ? 'set' : 'cleared') .
+            ' for <info>' . $version . '</info>' .
+            ' <comment>' . $migrations[$version]->getName() . '</comment>'
+        );
+    }
+
+    /**
+     * Remove all breakpoints
+     *
+     * @param string $environment
+     * @return void
+     */
+    public function removeBreakpoints($environment){
+        $this->getOutput()->writeln(sprintf(
+            ' %d breakpoints cleared.',
+            $this->getEnvironment($environment)->getAdapter()->resetAllBreakpoints()
+        ));
     }
 }

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -83,25 +83,27 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->once())
-            ->method('getVersionLog')
-            ->will($this->returnValue(
-                array (
-                    '20120111235330' =>
-                        array (
-                            'version' => '20120111235330',
-                            'start_time' => '2012-01-11 23:53:36',
-                            'end_time' => '2012-01-11 23:53:37',
-                            'migration_name' => '',
-                        ),
-                    '20120116183504' =>
-                        array (
-                            'version' => '20120116183504',
-                            'start_time' => '2012-01-16 18:35:40',
-                            'end_time' => '2012-01-16 18:35:41',
-                            'migration_name' => '',
-                        ),
-                )
-            ));
+                ->method('getVersionLog')
+                ->will($this->returnValue(
+                    array (
+                        '20120111235330' =>
+                            array (
+                                'version' => '20120111235330',
+                                'start_time' => '2012-01-11 23:53:36',
+                                'end_time' => '2012-01-11 23:53:37',
+                                'migration_name' => '',
+                                'breakpoint' => '0',
+                            ),
+                        '20120116183504' =>
+                            array (
+                                'version' => '20120116183504',
+                                'start_time' => '2012-01-16 18:35:40',
+                                'end_time' => '2012-01-16 18:35:41',
+                                'migration_name' => '',
+                                'breakpoint' => '0',
+                            ),
+                    )
+                ));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->getOutput()->setDecorated(false);
@@ -112,6 +114,43 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
         $this->assertRegExp('/up  20120111235330  2012-01-11 23:53:36  2012-01-11 23:53:37  TestMigration/', $outputStr);
         $this->assertRegExp('/up  20120116183504  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration2/', $outputStr);
+    }
+
+    public function testPrintStatusMethodWithBreakpointSet()
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->once())
+                ->method('getVersionLog')
+                ->will($this->returnValue(
+                    array (
+                        '20120111235330' =>
+                            array (
+                                'version' => '20120111235330',
+                                'start_time' => '2012-01-11 23:53:36',
+                                'end_time' => '2012-01-11 23:53:37',
+                                'migration_name' => '',
+                                'breakpoint' => '1',
+                            ),
+                        '20120116183504' =>
+                            array (
+                                'version' => '20120116183504',
+                                'start_time' => '2012-01-16 18:35:40',
+                                'end_time' => '2012-01-16 18:35:41',
+                                'migration_name' => '',
+                                'breakpoint' => '0',
+                            ),
+                    )
+                ));
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->getOutput()->setDecorated(false);
+        $return = $this->manager->printStatus('mockenv');
+        $this->assertEquals(0, $return);
+
+        rewind($this->manager->getOutput()->getStream());
+        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
+        $this->assertRegExp('/BREAKPOINT SET/', $outputStr);
     }
 
     public function testPrintStatusMethodWithNoMigrations()
@@ -140,25 +179,27 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->once())
-            ->method('getVersionLog')
-            ->will($this->returnValue(
-                array (
-                    '20120103083300' =>
-                        array (
-                            'version' => '20120103083300',
-                            'start_time' => '2012-01-11 23:53:36',
-                            'end_time' => '2012-01-11 23:53:37',
-                            'migration_name' => '',
-                        ),
-                    '20120815145812' =>
-                        array (
-                            'version' => '20120815145812',
-                            'start_time' => '2012-01-16 18:35:40',
-                            'end_time' => '2012-01-16 18:35:41',
-                            'migration_name' => 'Example',
-                        ),
-                )
-            ));
+                ->method('getVersionLog')
+                ->will($this->returnValue(
+                    array (
+                        '20120103083300' =>
+                            array (
+                                'version' => '20120103083300',
+                                'start_time' => '2012-01-11 23:53:36',
+                                'end_time' => '2012-01-11 23:53:37',
+                                'migration_name' => '',
+                                'breakpoint' => '0',
+                            ),
+                        '20120815145812' =>
+                            array (
+                                'version' => '20120815145812',
+                                'start_time' => '2012-01-16 18:35:40',
+                                'end_time' => '2012-01-16 18:35:41',
+                                'migration_name' => 'Example',
+                                'breakpoint' => '0',
+                            ),
+                    )
+                ));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->getOutput()->setDecorated(false);
@@ -168,6 +209,45 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
         $this->assertRegExp('/up  20120103083300  2012-01-11 23:53:36  2012-01-11 23:53:37  *\*\* MISSING \*\*/', $outputStr);
+        $this->assertRegExp('/up  20120815145812  2012-01-16 18:35:40  2012-01-16 18:35:41  Example   *\*\* MISSING \*\*/', $outputStr);
+    }
+
+    public function testPrintStatusMethodWithMissingMigrationsAndBreakpointSet()
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->once())
+                ->method('getVersionLog')
+                ->will($this->returnValue(
+                    array (
+                        '20120103083300' =>
+                            array (
+                                'version' => '20120103083300',
+                                'start_time' => '2012-01-11 23:53:36',
+                                'end_time' => '2012-01-11 23:53:37',
+                                'migration_name' => '',
+                                'breakpoint' => '1',
+                            ),
+                        '20120815145812' =>
+                            array (
+                                'version' => '20120815145812',
+                                'start_time' => '2012-01-16 18:35:40',
+                                'end_time' => '2012-01-16 18:35:41',
+                                'migration_name' => 'Example',
+                                'breakpoint' => '0',
+                            ),
+                    )
+                ));
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->getOutput()->setDecorated(false);
+        $return = $this->manager->printStatus('mockenv');
+        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+
+        rewind($this->manager->getOutput()->getStream());
+        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
+        $this->assertRegExp('/up  20120103083300  2012-01-11 23:53:36  2012-01-11 23:53:37  *\*\* MISSING \*\*/', $outputStr);
+        $this->assertRegExp('/BREAKPOINT SET/', $outputStr);
         $this->assertRegExp('/up  20120815145812  2012-01-16 18:35:40  2012-01-16 18:35:41  Example   *\*\* MISSING \*\*/', $outputStr);
     }
 
@@ -183,6 +263,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         'start_time' => '2012-01-16 18:35:40',
                         'end_time' => '2012-01-16 18:35:41',
                         'migration_name' => '',
+                        'breakpoint' => 0
                     ))));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
@@ -256,7 +337,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      * @param string $expectedMigration
      * @param string $message
      */
-    public function testMigrationsByDate($availableMigrations, $dateString, $expectedMigration, $message)
+    public function testMigrationsByDate(array $availableMigrations, $dateString, $expectedMigration, $message)
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
@@ -283,14 +364,18 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      * Test that migrating by date chooses the correct migration to point to.
      *
      * @dataProvider rollbackDateDataProvider
+     * @group bp
      */
-    public function testRollbacksByDate($availableRollbacks, $dateString, $expectedRollback, $message)
+    public function testRollbacksByDate(array $availableRollbacks, $dateString, $expectedRollback, $message)
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->any())
-            ->method('getVersions')
+            ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
+        $envStub->expects($this->any())
+                ->method('getVersions')
+                ->will($this->returnValue(array_keys($availableRollbacks)));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollbackToDateTime('mockenv', new \DateTime($dateString));
@@ -299,7 +384,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         if (is_null($expectedRollback)) {
             $this->assertEmpty($output, $message);
         } else {
-            $this->assertContains($expectedRollback, $output, $message);
+            $this->assertRegExp($expectedRollback, $output, $message);
         }
     }
 
@@ -325,13 +410,200 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function rollbackDateDataProvider()
     {
-        return array(
-            array(array('20120111235330', '20120116183504'), '20130118', null, 'Failed to rollback 0 migrations when rollback to date is later than all migrations'),
-            array(array('20120111235330', '20120116183504'), '20120116183504', 'No migrations to rollback', 'Failed to rollback 0 migrations when rollback to date is the most recent migration'),
-            array(array('20120111235330', '20120116183504'), '20120115', '20120116183504', 'Failed to rollback 1 migration when rollback date is between 2 migrations'),
-            array(array('20120111235330', '20120116183504'), '20120111235330', '20120116183504', 'Failed to rollback 1 migration when rollback datetime is the one of the migrations'),
-            array(array('20120111235330', '20120116183504'), '20110115', '20120111235330', 'Failed to rollback all the migrations when the rollback date is before all the migrations'),
-        );
+        return [
+
+            // No breakpoints set
+
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                ],
+                '20130118',
+                null,
+                'Failed to rollback 0 migrations when rollback to date is later than all migrations - no breakpoints set',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                ],
+                '20120116183504',
+                '`No migrations to rollback`',
+                'Failed to rollback 0 migrations when rollback to date is the most recent migration - no breakpoints set',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                ],
+                '20120115',
+                '`20120116183504`',
+                'Failed to rollback 1 migration when rollback date is between 2 migrations - no breakpoints set',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                ],
+                '20120111235330',
+                '`20120116183504`',
+                'Failed to rollback 1 migration when rollback datetime is the one of the migrations - no breakpoints set',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                ],
+                '20110115',
+                '`20120111235330`',
+                'Failed to rollback all the migrations when the rollback date is before all the migrations - no breakpoints set',
+            ],
+
+            // Breakpoint set on first migration
+
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                ],
+                '20130118',
+                null,
+                'Failed to rollback 0 migrations when rollback to date is later than all migrations - breakpoint set on first migration',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                ],
+                '20120116183504',
+                '`No migrations to rollback`',
+                'Failed to rollback 0 migrations when rollback to date is the most recent migration - breakpoint set on first migration',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                ],
+                '20120115',
+                '`20120116183504`',
+                'Failed to rollback 1 migration when rollback date is between 2 migrations - breakpoint set on first migration',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                ],
+                '20120111235330',
+                '`20120116183504`',
+                'Failed to rollback 1 migration when rollback datetime is the one of the migrations - breakpoint set on first migration',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                ],
+                '20110115',
+                '`(?!.*20120111235330.*)20120116183504.*Breakpoint reached.*`s',
+                'Failed to rollback 1 migration when the rollback date is before all the migrations and breakpoint set on first migration',
+            ],
+
+            // Breakpoint set on last migration
+
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                ],
+                '20130118',
+                null,
+                'Failed to rollback 0 migrations when rollback to date is later than all migrations - breakpoint set on last migration',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                ],
+                '20120116183504',
+                '`No migrations to rollback`',
+                'Failed to rollback 0 migrations when rollback to date is the most recent migration - breakpoint set on last migration',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                ],
+                '20120115',
+                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
+                'Failed to rollback 0 migrations when rollback date is between 2 migrations and breakpoint set on last migration',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                ],
+                '20120111235330',
+                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
+                'Failed to rollback 0 migrations when rollback datetime is the one of the migrations and breakpoint set on last migration',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                ],
+                '20110115',
+                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
+                'Failed to rollback 0 migrations when the rollback date is before all the migrations and breakpoint set on last migration',
+            ],
+
+            // Breakpoint set on all migration
+
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                ],
+                '20130118',
+                null,
+                'Failed to rollback 0 migrations when rollback to date is later than all migrations - breakpoint set on all migrations',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                ],
+                '20120116183504',
+                '`No migrations to rollback`',
+                'Failed to rollback 0 migrations when rollback to date is the most recent migration - breakpoint set on all migrations',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                ],
+                '20120115',
+                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
+                'Failed to rollback 0 migrations when rollback date is between 2 migrations and breakpoint set on all migrations',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                ],
+                '20120111235330',
+                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
+                'Failed to rollback 0 migrations when rollback datetime is the one of the migrations and breakpoint set on all migrations',
+            ],
+            [
+                [
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                ],
+                '20110115',
+                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
+                'Failed to rollback 0 migrations when the rollback date is before all the migrations and breakpoint set on all migrations',
+            ],
+        ];
     }
 
     public function testExecuteSeedWorksAsExpected()
@@ -450,5 +722,68 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($adapter->hasTable('user_logins'));
         $this->assertTrue($adapter->hasColumn('users', 'bio'));
         $this->assertFalse($adapter->hasForeignKey('user_logins', array('user_id')));
+    }
+
+    public function testBreakpointsOperateAsExpected()
+    {
+        if (!TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED) {
+            $this->markTestSkipped('Mysql tests disabled. See TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED constant.');
+        }
+        $configArray = $this->getConfigArray();
+        $adapter = $this->manager->getEnvironment('production')->getAdapter();
+
+        $config = new Config($configArray);
+
+        // ensure the database is empty
+        $adapter->dropDatabase(TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE);
+        $adapter->createDatabase(TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE);
+        $adapter->disconnect();
+
+        // migrate to the latest version
+        $this->manager->setConfig($config);
+        $this->manager->migrate('production');
+
+        // set breakpoint on most recent migration
+        $this->manager->toggleBreakpoint('production', null);
+
+        // ensure breakpoint is set
+        $versions = $this->manager->getEnvironment('production')->getVersionLog();
+        $this->assertEquals(1, end($versions)['breakpoint']);
+
+        // reset all breakpoints
+        $this->manager->removeBreakpoints('production');
+
+        // ensure breakpoint is not set
+        $versions = $this->manager->getEnvironment('production')->getVersionLog();
+        $this->assertEquals(0, end($versions)['breakpoint']);
+    }
+
+    public function testBreakpointWithInvalidVersion()
+    {
+        if (!TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED) {
+            $this->markTestSkipped('Mysql tests disabled. See TESTS_PHINX_DB_ADAPTER_MYSQL_ENABLED constant.');
+        }
+        $configArray = $this->getConfigArray();
+        $adapter = $this->manager->getEnvironment('production')->getAdapter();
+
+        $config = new Config($configArray);
+
+        // ensure the database is empty
+        $adapter->dropDatabase(TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE);
+        $adapter->createDatabase(TESTS_PHINX_DB_ADAPTER_MYSQL_DATABASE);
+        $adapter->disconnect();
+
+        // migrate to the latest version
+        $this->manager->setConfig($config);
+        $this->manager->migrate('production');
+        $this->manager->getOutput()->setDecorated(false);
+
+        // set breakpoint on most recent migration
+        $this->manager->toggleBreakpoint('production', 999);
+
+        rewind($this->manager->getOutput()->getStream());
+        $output = stream_get_contents($this->manager->getOutput()->getStream());
+
+        $this->assertContains('is not a valid version', $output);
     }
 }


### PR DESCRIPTION
Allow breakpoints to be set to stop accidental rollbacks. When a breakpoint is set, rollback will stop when it reaches that migration.
Can be overridden with --force.

Replaces PR https://github.com/robmorgan/phinx/pull/700 and is based upon 0.6.x-dev