### PR TITLE
Use the correct boolean value for "phinxlog.breakpoint" column in Postgres

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -460,7 +460,7 @@ abstract class PdoAdapter implements AdapterInterface
     {
         $this->query(
             sprintf(
-                'UPDATE %s SET breakpoint = CASE breakpoint WHEN 1 THEN 0 ELSE 1 END WHERE version = \'%s\';',
+                'UPDATE %s SET breakpoint = CASE breakpoint WHEN true THEN false ELSE true END WHERE version = \'%s\';',
                 $this->getSchemaTableName(),
                 $migration->getversion()
             )

--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1053,7 +1053,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(
-                "INSERT INTO %s (version, migration_name, start_time, end_time, breakpoint) VALUES ('%s', '%s', '%s', '%s', 0);",
+                "INSERT INTO %s (version, migration_name, start_time, end_time, breakpoint) VALUES ('%s', '%s', '%s', '%s', false);",
                 $this->getSchemaTableName(),
                 $migration->getVersion(),
                 substr($migration->getName(), 0, 100),


### PR DESCRIPTION
This small fix avoid the Exception message:
`SQLSTATE[42804]: Datatype mismatch: 7 ERROR:  column "breakpoint" is of type boolean but expression is of type integer`