### PR TITLE
Standardise the breakpoint related queries

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -496,4 +496,12 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     {
         return $this->getAdapter()->dropDatabase($name);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function castToBool($value)
+    {
+        return $this->getAdapter()->castToBool($value);
+    }
 }

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -382,7 +382,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         if (is_string($default) && 'CURRENT_TIMESTAMP' !== $default) {
             $default = $this->getConnection()->quote($default);
         } elseif (is_bool($default)) {
-            $default = (int) $default;
+            $default = $this->castToBool($default);
         }
         return isset($default) ? ' DEFAULT ' . $default : '';
     }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -219,7 +219,7 @@ abstract class PdoAdapter implements AdapterInterface
             }
             if (!$table->hasColumn('breakpoint')) {
                 $table
-                    ->addColumn('breakpoint', 'boolean', array('default' => 0))
+                    ->addColumn('breakpoint', 'boolean', array('default' => false))
                     ->save();
             }
         }
@@ -422,28 +422,27 @@ abstract class PdoAdapter implements AdapterInterface
         if (strcasecmp($direction, MigrationInterface::UP) === 0) {
             // up
             $sql = sprintf(
-                'INSERT INTO %s ('
-                . 'version, migration_name, start_time, end_time, breakpoint'
-                . ') VALUES ('
-                . '\'%s\','
-                . '\'%s\','
-                . '\'%s\','
-                . '\'%s\','
-                . '0'
-                . ');',
+                "INSERT INTO %s (%s, %s, %s, %s, %s) VALUES ('%s', '%s', '%s', '%s', %s);",
                 $this->getSchemaTableName(),
+                $this->quoteColumnName('version'),
+                $this->quoteColumnName('migration_name'),
+                $this->quoteColumnName('start_time'),
+                $this->quoteColumnName('end_time'),
+                $this->quoteColumnName('breakpoint'),
                 $migration->getVersion(),
                 substr($migration->getName(), 0, 100),
                 $startTime,
-                $endTime
+                $endTime,
+                $this->castToBool(false)
             );
 
             $this->query($sql);
         } else {
             // down
             $sql = sprintf(
-                "DELETE FROM %s WHERE version = '%s'",
+                "DELETE FROM %s WHERE %s = '%s'",
                 $this->getSchemaTableName(),
+                $this->quoteColumnName('version'),
                 $migration->getVersion()
             );
 
@@ -460,9 +459,13 @@ abstract class PdoAdapter implements AdapterInterface
     {
         $this->query(
             sprintf(
-                'UPDATE %s SET breakpoint = CASE breakpoint WHEN 1 THEN 0 ELSE 1 END WHERE version = \'%s\';',
+                'UPDATE %1$s SET %2$s = CASE %2$s WHEN %3$s THEN %4$s ELSE %3$s END WHERE %5$s = \'%6$s\';',
                 $this->getSchemaTableName(),
-                $migration->getversion()
+                $this->quoteColumnName('breakpoint'),
+                $this->castToBool(true),
+                $this->castToBool(false),
+                $this->quoteColumnName('version'),
+                $migration->getVersion()
             )
         );
 
@@ -476,8 +479,10 @@ abstract class PdoAdapter implements AdapterInterface
     {
         return $this->execute(
             sprintf(
-                'UPDATE %s SET breakpoint = 0 WHERE breakpoint <> 0;',
-                $this->getSchemaTableName()
+                'UPDATE %1$s SET %2$s = %3$s WHERE %2$s <> %3$s;',
+                $this->getSchemaTableName(),
+                $this->quoteColumnName('breakpoint'),
+                $this->castToBool(false)
             )
         );
     }
@@ -509,14 +514,14 @@ abstract class PdoAdapter implements AdapterInterface
                       ->addColumn('migration_name', 'string', array('limit' => 100, 'default' => null, 'null' => true))
                       ->addColumn('start_time', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
                       ->addColumn('end_time', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
-                      ->addColumn('breakpoint', 'boolean', array('default' => 0))
+                      ->addColumn('breakpoint', 'boolean', array('default' => false))
                       ->save();
             } else {
                 $table->addColumn('version', 'biginteger')
                       ->addColumn('migration_name', 'string', array('limit' => 100, 'default' => null, 'null' => true))
                       ->addColumn('start_time', 'timestamp')
                       ->addColumn('end_time', 'timestamp')
-                      ->addColumn('breakpoint', 'boolean')
+                      ->addColumn('breakpoint', 'boolean', array('default' => false))
                       ->save();
             }
         } catch (\Exception $exception) {
@@ -567,5 +572,17 @@ abstract class PdoAdapter implements AdapterInterface
      */
     public function isValidColumnType(Column $column) {
         return in_array($column->getType(), $this->getColumnTypes());
+    }
+
+    /**
+     * Cast a value to a boolean appropriate for the adapter.
+     *
+     * @param mixed $value The value to be cast
+     *
+     * @return mixed
+     */
+    public function castToBool($value)
+    {
+        return (bool) $value ? 1 : 0;
     }
 }

--- a/src/Phinx/Db/Adapter/SQLiteAdapter.php
+++ b/src/Phinx/Db/Adapter/SQLiteAdapter.php
@@ -1015,7 +1015,7 @@ class SQLiteAdapter extends PdoAdapter implements AdapterInterface
         if (is_string($default) && 'CURRENT_TIMESTAMP' !== $default) {
             $default = $this->getConnection()->quote($default);
         } elseif (is_bool($default)) {
-            $default = (int) $default;
+            $default = $this->castToBool($default);
         }
         return isset($default) ? ' DEFAULT ' . $default : '';
     }

--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -32,7 +32,6 @@ use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
 use Phinx\Db\Table\Index;
 use Phinx\Db\Table\ForeignKey;
-use Phinx\Migration\MigrationInterface;
 
 /**
  * Phinx SqlServer Adapter.
@@ -1056,7 +1055,7 @@ SQL;
         if (is_string($default) && 'CURRENT_TIMESTAMP' !== $default) {
             $default = $this->getConnection()->quote($default);
         } elseif (is_bool($default)) {
-            $default = (int) $default;
+            $default = $this->castToBool($default);
         }
         return isset($default) ? ' DEFAULT ' . $default : '';
     }
@@ -1163,35 +1162,5 @@ SQL;
     public function getColumnTypes()
     {
         return array_merge(parent::getColumnTypes(), array('filestream'));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime) {
-        if (strcasecmp($direction, MigrationInterface::UP) === 0) {
-            // up
-            $sql = sprintf(
-                "INSERT INTO %s ([version], [migration_name], [start_time], [end_time], [breakpoint]) VALUES ('%s', '%s', '%s', '%s', 0);",
-                $this->getSchemaTableName(),
-                $migration->getVersion(),
-                substr($migration->getName(), 0, 100),
-                $startTime,
-                $endTime
-            );
-
-            $this->query($sql);
-        } else {
-            // down
-            $sql = sprintf(
-                "DELETE FROM %s WHERE [version] = '%s'",
-                $this->getSchemaTableName(),
-                $migration->getVersion()
-            );
-
-            $this->query($sql);
-        }
-
-        return $this;
     }
 }


### PR DESCRIPTION
Introduces a new method \Phinx\Db\Adapter\PdoAdapter::castToBool()
By default, 0 and 1 are fine for mysql, sqlite and sqlsrv for boolean types.
Postgres must use true and false for boolean types.

Fixes/replaces PR #876