### PR TITLE
Fix failing phpunit for hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,14 @@ php:
   - 7
   - hhvm
 
-matrix:
-    allow_failures:
-        - php: hhvm
-
 before_script:
     - travis_retry composer self-update
-    - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source --prefer-stable --prefer-lowest
+    - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source --prefer-stable
     - mysql -e 'create database phinx_testing;'
     - psql -c 'create database phinx_testing;' -U postgres
 
 script:
-    - phpunit --coverage-text --coverage-clover=coverage.clover
+    - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
     - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/yaml": "~2.8|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^3.7|^4.0|^5.0"
+        "phpunit/phpunit": "^4.0|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterUnitTest.php
@@ -394,8 +394,8 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         $foreignkey->expects($this->any())->method('getConstraint')->will($this->returnValue('fk1'));
         $foreignkey->expects($this->any())->method('getReferencedColumns')->will($this->returnValue(array('id')));
         $foreignkey->expects($this->any())->method('getReferencedTable')->will($this->returnValue($refTable));
-        $foreignkey->expects($this->any())->method('onDelete')->will($this->returnValue(null));
-        $foreignkey->expects($this->any())->method('onUpdate')->will($this->returnValue(null));
+        $foreignkey->expects($this->any())->method('getOnDelete')->will($this->returnValue(null));
+        $foreignkey->expects($this->any())->method('getOnUpdate')->will($this->returnValue(null));
 
         $table->expects($this->any())->method('getPendingColumns')->will($this->returnValue(array($column1, $column2, $column3)));
         $table->expects($this->any())->method('getName')->will($this->returnValue('table_name'));
@@ -1391,8 +1391,8 @@ class MysqlAdapterUnitTest extends \PHPUnit_Framework_TestCase
         $foreignkey->expects($this->any())->method('getConstraint')->will($this->returnValue('fk1'));
         $foreignkey->expects($this->any())->method('getReferencedColumns')->will($this->returnValue(array('id')));
         $foreignkey->expects($this->any())->method('getReferencedTable')->will($this->returnValue($refTable));
-        $foreignkey->expects($this->any())->method('onDelete')->will($this->returnValue(null));
-        $foreignkey->expects($this->any())->method('onUpdate')->will($this->returnValue(null));
+        $foreignkey->expects($this->any())->method('getOnDelete')->will($this->returnValue(null));
+        $foreignkey->expects($this->any())->method('getOnUpdate')->will($this->returnValue(null));
 
         $this->assertExecuteSql('ALTER TABLE `table_name` ADD  CONSTRAINT `fk1` FOREIGN KEY (`other_table_id`) REFERENCES `other_table` (`id`)');
         $this->adapter->addForeignKey($table, $foreignkey);


### PR DESCRIPTION
The pre-built/installed version of PHPUnit that is run doesn't seem to have an uptodate version of php-token-stream.
So, rather than using that version, run with the composer provided version.