### PR TITLE
Fix - removeColumn in change() instead of up()

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -897,13 +897,13 @@ To drop a column, use the ``removeColumn()`` method.
         class MyNewMigration extends AbstractMigration
         {
             /**
-             * Change Method.
+             * Migrate up.
              */
-            public function change()
+            public function up()
             {
                 $table = $this->table('users');
                 $table->removeColumn('short_name')
-                      ->update();
+                      ->save();
             }
         }
 


### PR DESCRIPTION
Method removeColumn() is not supported in change() method according to http://docs.phinx.org/en/latest/migrations.html#dropping-a-column.