### PR TITLE
Fixed rollback process for 2 migrations case

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -391,7 +391,7 @@ class Manager
         if (null === $version) {
             // Get the migration before the last run migration
             $prev = count($versions) - 2;
-            $version =  $prev <= 0 ? 0 : $versions[$prev];
+            $version =  $prev < 0 ? 0 : $versions[$prev];
         } else {
             // Get the first migration number
             $first = $versions[0];


### PR DESCRIPTION
This is a very small fix for such situation when you have exactly 2 migrations in your migrations table and call 'phinx rollback' will rollback not just last one migration but both two migrations at once. I've fixed this case so it will process just one last migration in this case.