### PR TITLE
Rollbacks by start time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version History
 
+**0.7.x-dev** (***)
+
+* New features
+  * [#885](https://github.com/robmorgan/phinx/pull/885) Add `collation` and `encoding` options for MySQL text and char columns
+
 **0.6.x-dev** (***)
 
 * Documentation updates

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -127,12 +127,31 @@ Specifying 0 as the target version will revert all migrations.
 
         $ phinx rollback -e development -t 0
 
+To rollback all migrations to a specific date then use the ``--date``
+parameter or ``-d`` for short.
+
+.. code-block:: bash
+
+        $ phinx rollback -e development -d 2012
+        $ phinx rollback -e development -d 201201
+        $ phinx rollback -e development -d 20120103
+        $ phinx rollback -e development -d 2012010312
+        $ phinx rollback -e development -d 201201031205
+        $ phinx rollback -e development -d 20120103120530
+
 If a breakpoint is set, blocking further rollbacks, you can override the
 breakpoint using the ``--force`` parameter or ``-f`` for short.
 
 .. code-block:: bash
 
         $ phinx rollback -e development -t 0 -f
+
+.. note::
+
+        When rolling back, Phinx orders the executed migrations using 
+        the order specified in the ``version_order`` option of your 
+        ``phinx.yml`` file.
+        Please see the :doc:`Configuration <configuration>` chapter for more information.
 
 The Status Command
 ------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -280,3 +280,12 @@ The aliased classes will still be required to implement the ``Phinx\Migration\Cr
     aliases:
         permission: \Namespace\Migrations\PermissionMigrationTemplateGenerator
         view: \Namespace\Migrations\ViewMigrationTemplateGenerator
+
+Version Order
+------
+
+When rolling back or printing the status of migrations, Phinx orders the executed migrations according to the 
+``version_order`` option, which can have the following values:
+
+* ``creation-time`` (the default): migrations are ordered by their creation time, which is also part of their filename.
+* ``start-time``: migrations are ordered by their start time, also known as execution time.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -287,5 +287,5 @@ Version Order
 When rolling back or printing the status of migrations, Phinx orders the executed migrations according to the 
 ``version_order`` option, which can have the following values:
 
-* ``creation-time`` (the default): migrations are ordered by their creation time, which is also part of their filename.
-* ``start-time``: migrations are ordered by their start time, also known as execution time.
+* ``creation`` (the default): migrations are ordered by their creation time, which is also part of their filename.
+* ``execution``: migrations are ordered by their execution time, also known as start time.

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -711,6 +711,15 @@ Option   Description
 signed   enable or disable the ``unsigned`` option *(only applies to MySQL)*
 ======== ===========
 
+For ``string`` and ``text`` columns:
+
+========= ===========
+Option    Description
+========= ===========
+collation set collation that differs from table defaults *(only applies to MySQL)*
+encoding  set character set that differs from table defaults *(only applies to MySQL)*
+========= ===========
+
 For foreign key definitions:
 
 ====== ===========

--- a/phinx.yml
+++ b/phinx.yml
@@ -31,3 +31,5 @@ environments:
         pass: ''
         port: 3306
         charset: utf8
+
+version_order: creation-time

--- a/phinx.yml
+++ b/phinx.yml
@@ -32,4 +32,4 @@ environments:
         port: 3306
         charset: utf8
 
-version_order: creation-time
+version_order: creation

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -39,6 +39,16 @@ use Symfony\Component\Yaml\Yaml;
 class Config implements ConfigInterface
 {
     /**
+     * The value that identifies a version order by creation time.
+     */
+    const VERSION_ORDER_CREATION_TIME = 'creation-time';
+
+    /**
+     * The value that identifies a version order by start time.
+     */
+    const VERSION_ORDER_START_TIME = 'start-time';
+
+    /**
      * @var array
      */
     private $values = array();
@@ -55,6 +65,8 @@ class Config implements ConfigInterface
     {
         $this->configFilePath = $configFilePath;
         $this->values = $this->replaceTokens($configArray);
+
+        $this->setVersionOrder();
     }
 
     /**
@@ -292,6 +304,58 @@ class Config implements ConfigInterface
 
         return $this->values['templates']['class'];
      }
+
+    /**
+     * Get the version order.
+     *
+     * @return string
+     */
+    public function getVersionOrder()
+    {
+        return $this->values['version_order'];
+    }
+
+    /**
+     * Set the version order.
+     * @param string $versionOrder The Version Order to set.
+     */
+    public function setVersionOrder($versionOrder = null)
+    {
+        if (!isset($versionOrder)) {
+            $versionOrder = isset ( $this->values['version_order'] ) ? $this->values['version_order'] : null;
+        }
+
+        if (!isset($versionOrder)) {
+            // if the configuration value is missing we use the default version order (creation time)
+            $this->values['version_order'] = self::VERSION_ORDER_CREATION_TIME;
+            return;
+        }
+
+        $validVersionOrders = array(self::VERSION_ORDER_CREATION_TIME, self::VERSION_ORDER_START_TIME);
+
+        if (!in_array($versionOrder, $validVersionOrders)) {
+            throw new \RuntimeException(sprintf(
+                'Invalid version_order configuration option: %s. Valid values: %s',
+                $versionOrder, implode (' or ', $validVersionOrders)
+            ));
+        }
+
+        $this->values['version_order'] = $versionOrder;
+    }
+    
+    /**
+     * Is version order creation time?
+     *
+     * @return boolean
+     */
+    public function isVersionOrderCreationTime()
+    {
+        $versionOrder = $this->getVersionOrder();
+
+        return $versionOrder == self::VERSION_ORDER_CREATION_TIME;
+    }
+
+    
 
     /**
      * Replace tokens in the specified array.

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -41,12 +41,12 @@ class Config implements ConfigInterface
     /**
      * The value that identifies a version order by creation time.
      */
-    const VERSION_ORDER_CREATION_TIME = 'creation-time';
+    const VERSION_ORDER_CREATION_TIME = 'creation';
 
     /**
-     * The value that identifies a version order by start time.
+     * The value that identifies a version order by execution time.
      */
-    const VERSION_ORDER_START_TIME = 'start-time';
+    const VERSION_ORDER_EXECUTION_TIME = 'execution';
 
     /**
      * @var array
@@ -331,7 +331,7 @@ class Config implements ConfigInterface
             return;
         }
 
-        $validVersionOrders = array(self::VERSION_ORDER_CREATION_TIME, self::VERSION_ORDER_START_TIME);
+        $validVersionOrders = array(self::VERSION_ORDER_CREATION_TIME, self::VERSION_ORDER_EXECUTION_TIME);
 
         if (!in_array($versionOrder, $validVersionOrders)) {
             throw new \RuntimeException(sprintf(

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -65,8 +65,6 @@ class Config implements ConfigInterface
     {
         $this->configFilePath = $configFilePath;
         $this->values = $this->replaceTokens($configArray);
-
-        $this->setVersionOrder();
     }
 
     /**
@@ -312,37 +310,13 @@ class Config implements ConfigInterface
      */
     public function getVersionOrder()
     {
+        if (!isset($this->values['version_order'])) {
+            return self::VERSION_ORDER_CREATION_TIME;
+        }
+
         return $this->values['version_order'];
     }
 
-    /**
-     * Set the version order.
-     * @param string $versionOrder The Version Order to set.
-     */
-    public function setVersionOrder($versionOrder = null)
-    {
-        if (!isset($versionOrder)) {
-            $versionOrder = isset ( $this->values['version_order'] ) ? $this->values['version_order'] : null;
-        }
-
-        if (!isset($versionOrder)) {
-            // if the configuration value is missing we use the default version order (creation time)
-            $this->values['version_order'] = self::VERSION_ORDER_CREATION_TIME;
-            return;
-        }
-
-        $validVersionOrders = array(self::VERSION_ORDER_CREATION_TIME, self::VERSION_ORDER_EXECUTION_TIME);
-
-        if (!in_array($versionOrder, $validVersionOrders)) {
-            throw new \RuntimeException(sprintf(
-                'Invalid version_order configuration option: %s. Valid values: %s',
-                $versionOrder, implode (' or ', $validVersionOrders)
-            ));
-        }
-
-        $this->values['version_order'] = $versionOrder;
-    }
-    
     /**
      * Is version order creation time?
      *

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -109,7 +109,7 @@ EOT
         }
         
         $versionOrder = $this->getConfig()->getVersionOrder();
-        $output->writeln('<info>ordering by </info>' . $versionOrder);
+        $output->writeln('<info>ordering by </info>' . $versionOrder . " time");
 
         // rollback the specified environment
         if (null === $date) {

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -137,8 +137,7 @@ EOT
     public function getTargetFromDate($date)
     {
         if (!preg_match('/^\d{4,14}$/', $date)) {
-            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
-                'part, but the missing part(s) must all be in the end of the date string)');
+            throw new \InvalidArgumentException('Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].');
         }
 
         // what we need to append to the date according to the possible date string lengths
@@ -156,15 +155,13 @@ EOT
         }
 
         if ($target === null) {
-            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
-                'part, but the missing part(s) must all be in the end of the date string)');
+            throw new \InvalidArgumentException('Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].');
         }
 
         $dateTime = \DateTime::createFromFormat('YmdHis', $target);
 
         if ($dateTime === false) {
-            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
-                'part, but the missing part(s) must all be in the end of the date string)');
+            throw new \InvalidArgumentException('Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].');
         }
 
         return $dateTime->format('YmdHis');

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -31,6 +31,7 @@ namespace Phinx\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Phinx\Config\Config;
 
 class Rollback extends AbstractCommand
 {
@@ -61,6 +62,10 @@ The <info>rollback</info> command reverts the last migration, or optionally up t
 If you have a breakpoint set, then you can rollback to target 0 and the rollbacks will stop at the breakpoint.
 <info>phinx rollback -e development -t 0 </info>
 
+The <info>version_order</info> configuration option is used to determine the order of the migrations when rolling back.
+This can be used to allow the rolling back of the last executed migration instead of the last created one, or combined 
+with the <info>-d|--date</info> option to rollback to a certain date using the migration start times to order them.
+
 EOT
              );
     }
@@ -81,14 +86,16 @@ EOT
         $date        = $input->getOption('date');
         $force       = !!$input->getOption('force');
 
+        $config = $this->getConfig();
+
         if (null === $environment) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
+            $environment = $config->getDefaultEnvironment();
             $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
         } else {
             $output->writeln('<info>using environment</info> ' . $environment);
         }
 
-        $envOptions = $this->getConfig()->getEnvironment($environment);
+        $envOptions = $config->getEnvironment($environment);
         if (isset($envOptions['adapter'])) {
             $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
         }
@@ -100,17 +107,66 @@ EOT
         if (isset($envOptions['name'])) {
             $output->writeln('<info>using database</info> ' . $envOptions['name']);
         }
+        
+        $versionOrder = $this->getConfig()->getVersionOrder();
+        $output->writeln('<info>ordering by </info>' . $versionOrder);
 
         // rollback the specified environment
-        $start = microtime(true);
-        if (null !== $date) {
-            $this->getManager()->rollbackToDateTime($environment, new \DateTime($date), $force);
+        if (null === $date) {
+            $targetMustMatchVersion = true;
+            $target = $version;
         } else {
-            $this->getManager()->rollback($environment, $version, $force);
+            $targetMustMatchVersion = false;
+            $target = $this->getTargetFromDate($date);
         }
+
+        $start = microtime(true);
+        $this->getManager()->rollback($environment, $target, $force, $targetMustMatchVersion);
         $end = microtime(true);
 
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+    }
+
+    /**
+     * Get Target from Date
+     *
+     * @param string $date The date to convert to a target.
+     * @return The target
+     */
+    public function getTargetFromDate($date)
+    {
+        if (!preg_match('/^\d{4,14}$/', $date)) {
+            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
+                'part, but the missing part(s) must all be in the end of the date string)');
+        }
+
+        // what we need to append to the date according to the possible date string lengths
+        $dateStrlenToAppend = array(
+            14 => '',
+            12 => '00',
+            10 => '0000',
+            8 => '000000',
+            6 => '01000000',
+            4 => '0101000000',
+        );
+
+        if (isset($dateStrlenToAppend[strlen($date)])) {
+            $target = $date . $dateStrlenToAppend[strlen($date)];
+        }
+
+        if ($target === null) {
+            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
+                'part, but the missing part(s) must all be in the end of the date string)');
+        }
+
+        $dateTime = \DateTime::createFromFormat('YmdHis', $target);
+
+        if ($dateTime === false) {
+            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
+                'part, but the missing part(s) must all be in the end of the date string)');
+        }
+
+        return $dateTime->format('YmdHis');
     }
 }

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -82,7 +82,7 @@ EOT
             $output->writeln('<info>using format</info> ' . $format);
         }
 
-        $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder());
+        $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder() . " time");
 
         // print the status
         return $this->getManager()->printStatus($environment, $format);

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -52,6 +52,8 @@ The <info>status</info> command prints a list of all migrations, along with thei
 
 <info>phinx status -e development</info>
 <info>phinx status -e development -f json</info>
+
+The <info>version_order</info> configuration option is used to determine the order of the status migrations.
 EOT
              );
     }
@@ -79,6 +81,8 @@ EOT
         if (null !== $format) {
             $output->writeln('<info>using format</info> ' . $format);
         }
+
+        $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder());
 
         // print the status
         return $this->getManager()->printStatus($environment, $format);

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -81,8 +81,9 @@ interface AdapterInterface
     public function getVersions();
 
     /**
-     * Get all migration log entries, indexed by version number.
-     *
+     * Get all migration log entries, indexed by version creation time and sorted ascendingly by the configuration's 
+     * version order option
+     * 
      * @return array
      */
     public function getVersionLog();

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1034,6 +1034,8 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         if (($values = $column->getValues()) && is_array($values)) {
             $def .= "('" . implode("', '", $values) . "')";
         }
+        $def .= $column->getEncoding() ? ' CHARACTER SET ' . $column->getEncoding() : '';
+        $def .= $column->getCollation() ? ' COLLATE ' . $column->getCollation() : '';
         $def .= (!$column->isSigned() && isset($this->signedColumnTypes[$column->getType()])) ? ' unsigned' : '' ;
         $def .= ($column->isNull() == false) ? ' NOT NULL' : ' NULL';
         $def .= ($column->isIdentity()) ? ' AUTO_INCREMENT' : '';

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -411,7 +411,7 @@ abstract class PdoAdapter implements AdapterInterface
             case \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME:
                 $orderBy = 'version ASC';
                 break;
-            case \Phinx\Config\Config::VERSION_ORDER_START_TIME:
+            case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
                 $orderBy = 'start_time ASC, version ASC';
                 break;
         }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -406,8 +406,18 @@ abstract class PdoAdapter implements AdapterInterface
     public function getVersionLog()
     {
         $result = array();
-        $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY version ASC', $this->getSchemaTableName()));
-        foreach ($rows as $version) {
+
+        switch ($this->options['version_order']) {
+            case \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME:
+                $orderBy = 'version ASC';
+                break;
+            case \Phinx\Config\Config::VERSION_ORDER_START_TIME:
+                $orderBy = 'start_time ASC, version ASC';
+                break;
+        }
+
+        $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY %s', $this->getSchemaTableName(), $orderBy));
+        foreach($rows as $version) {
             $result[$version['version']] = $version;
         }
 

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -414,6 +414,8 @@ abstract class PdoAdapter implements AdapterInterface
             case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
                 $orderBy = 'start_time ASC, version ASC';
                 break;
+            default:
+                throw new \RuntimeException('Invalid version_order configuration option');
         }
 
         $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY %s', $this->getSchemaTableName(), $orderBy));

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -28,6 +28,8 @@
  */
 namespace Phinx\Db\Table;
 
+use Phinx\Db\Adapter\AdapterInterface;
+
 /**
  *
  * This object is based loosely on: http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html.
@@ -103,6 +105,16 @@ class Column
      * @var array
      */
     protected $properties = array();
+
+    /**
+     * @var string
+     */
+    protected $collation;
+
+    /**
+     * @var string
+     */
+    protected $encoding;
 
     /**
      * @var array
@@ -486,6 +498,72 @@ class Column
     }
 
     /**
+     * Sets the column collation.
+     *
+     * @param string $collation
+     *
+     * @throws \UnexpectedValueException If collation not allowed for type
+     * @return $this
+     */
+    public function setCollation($collation)
+    {
+        $allowedTypes = array(
+            AdapterInterface::PHINX_TYPE_CHAR,
+            AdapterInterface::PHINX_TYPE_STRING,
+            AdapterInterface::PHINX_TYPE_TEXT,
+        );
+        if (!in_array($this->getType(), $allowedTypes))
+            throw new \UnexpectedValueException('Collation may be set only for types: ' . implode(', ', $allowedTypes));
+
+        $this->collation = $collation;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column collation.
+     *
+     * @return string
+     */
+    public function getCollation()
+    {
+        return $this->collation;
+    }
+
+    /**
+     * Sets the column character set.
+     *
+     * @param string $encoding
+     *
+     * @throws \UnexpectedValueException If character set not allowed for type
+     * @return $this
+     */
+    public function setEncoding($encoding)
+    {
+        $allowedTypes = array(
+            AdapterInterface::PHINX_TYPE_CHAR,
+            AdapterInterface::PHINX_TYPE_STRING,
+            AdapterInterface::PHINX_TYPE_TEXT,
+        );
+        if (!in_array($this->getType(), $allowedTypes))
+            throw new \UnexpectedValueException('Character set may be set only for types: ' . implode(', ', $allowedTypes));
+
+        $this->encoding = $encoding;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column character set.
+     *
+     * @return string
+     */
+    public function getEncoding()
+    {
+        return $this->encoding;
+    }
+
+    /**
      * Gets all allowed options. Each option must have a corresponding `setFoo` method.
      *
      * @return array
@@ -506,6 +584,8 @@ class Column
             'timezone',
             'properties',
             'values',
+            'collation',
+            'encoding',
         );
     }
 

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -115,7 +115,7 @@ class Manager
                 case \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME:
                     $migrationIdAndStartedHeader = "<info>[Migration ID]</info>  Started            ";
                     break;
-                case \Phinx\Config\Config::VERSION_ORDER_START_TIME:
+                case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
                     $migrationIdAndStartedHeader = "Migration ID    <info>[Started          ]</info>";
                     break;
             }
@@ -426,7 +426,7 @@ class Manager
         $sortedMigrations = array();
 
         foreach ($executedVersions as $versionCreationTime => &$executedVersion) {
-            // if we have a date (ie. the target must not match a version) and we are sorting by start time, we
+            // if we have a date (ie. the target must not match a version) and we are sorting by execution time, we
             // convert the version start time so we can compare directly with the target date
             if (!$this->getConfig()->isVersionOrderCreationTime() && !$targetMustMatchVersion) {
                 $dateTime = \DateTime::createFromFormat('Y-m-d H:i:s', $executedVersion['start_time']);

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -118,6 +118,8 @@ class Manager
                 case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
                     $migrationIdAndStartedHeader = "Migration ID    <info>[Started          ]</info>";
                     break;
+                default:
+                    throw new \RuntimeException('Invalid version_order configuration option');
             }
 
             $output->writeln(" Status  $migrationIdAndStartedHeader  Finished             Migration Name ");

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -229,7 +229,8 @@ class Environment
     }
 
     /**
-     * Get all migration log entries, indexed by version number.
+     * Get all migration log entries, indexed by version creation time and sorted ascendingly by the configuration's 
+     * version_order option
      *
      * @return array
      */

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -18,6 +18,8 @@ class ConfigTest extends AbstractConfigTest
     public function testConstructEmptyArguments()
     {
         $config = new Config(array());
+        // this option is set to its default value when not being passed in the constructor, so we can ignore it
+        unset($config['version_order']);
         $this->assertAttributeEmpty('values', $config);
         $this->assertAttributeEquals(null, 'configFilePath', $config);
         $this->assertNull($config->getConfigFilePath());
@@ -208,4 +210,79 @@ class ConfigTest extends AbstractConfigTest
         $config = new \Phinx\Config\Config(array());
         $this->assertEquals('db/seeds', $config->getSeedPath());
     }
+
+    /**
+     * @covers \Phinx\Config\Config::getVersionOrder
+     */
+    public function testGetVersionOrder()
+    {
+        $config = new \Phinx\Config\Config(array());
+        $config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_START_TIME, $config->getVersionOrder());
+    }
+
+    /**
+     * @covers \Phinx\Config\Config::setVersionOrder
+     */
+    public function testSetVersionOrder()
+    {
+        $config = new \Phinx\Config\Config(array());
+        $config->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_START_TIME);
+        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_START_TIME, $config['version_order']);
+    }
+
+    /**
+     * @covers \Phinx\Config\Config::setVersionOrder
+     */
+    public function testSetVersionOrderDefault()
+    {
+        $config = new \Phinx\Config\Config(array());
+        $config->setVersionOrder();
+        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, $config['version_order']);
+    }
+    
+    /**
+     * @covers \Phinx\Config\Config::setVersionOrder
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Invalid version_order configuration option: bad-order. Valid values: creation-time or start-time
+     */
+    public function testSetVersionOrderThrowsException()
+    {
+        $config = new \Phinx\Config\Config(array());
+        $config->setVersionOrder('bad-order');
+    }
+
+    /**
+     * @covers \Phinx\Config\Config::isVersionOrderCreationTime
+     * @dataProvider isVersionOrderCreationTimeDataProvider
+     */
+    public function testIsVersionOrderCreationTime($versionOrder, $expected)
+    {
+        // get config stub
+        $configStub = $this->getMock('\Phinx\Config\Config', array('getVersionOrder'), array(array()));
+
+        $configStub->expects($this->once())
+            ->method('getVersionOrder')
+            ->will($this->returnValue($versionOrder));
+
+        $this->assertEquals($expected, $configStub->isVersionOrderCreationTime());
+    }
+
+    /**
+     * @covers \Phinx\Config\Config::isVersionOrderCreationTime
+     */
+    public function isVersionOrderCreationTimeDataProvider()
+    {
+        return [
+            'With Creation Time Version Order' =>
+            [
+                \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, true
+            ],
+            'With Start Time Version Order' =>
+            [
+                \Phinx\Config\Config::VERSION_ORDER_START_TIME, false
+            ],
+        ];
+    }
+
 }

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -222,37 +222,6 @@ class ConfigTest extends AbstractConfigTest
     }
 
     /**
-     * @covers \Phinx\Config\Config::setVersionOrder
-     */
-    public function testSetVersionOrder()
-    {
-        $config = new \Phinx\Config\Config(array());
-        $config->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
-        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, $config['version_order']);
-    }
-
-    /**
-     * @covers \Phinx\Config\Config::setVersionOrder
-     */
-    public function testSetVersionOrderDefault()
-    {
-        $config = new \Phinx\Config\Config(array());
-        $config->setVersionOrder();
-        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, $config['version_order']);
-    }
-    
-    /**
-     * @covers \Phinx\Config\Config::setVersionOrder
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Invalid version_order configuration option: bad-order. Valid values: creation or execution
-     */
-    public function testSetVersionOrderThrowsException()
-    {
-        $config = new \Phinx\Config\Config(array());
-        $config->setVersionOrder('bad-order');
-    }
-
-    /**
      * @covers \Phinx\Config\Config::isVersionOrderCreationTime
      * @dataProvider isVersionOrderCreationTimeDataProvider
      */

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -217,8 +217,8 @@ class ConfigTest extends AbstractConfigTest
     public function testGetVersionOrder()
     {
         $config = new \Phinx\Config\Config(array());
-        $config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
-        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_START_TIME, $config->getVersionOrder());
+        $config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, $config->getVersionOrder());
     }
 
     /**
@@ -227,8 +227,8 @@ class ConfigTest extends AbstractConfigTest
     public function testSetVersionOrder()
     {
         $config = new \Phinx\Config\Config(array());
-        $config->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_START_TIME);
-        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_START_TIME, $config['version_order']);
+        $config->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
+        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, $config['version_order']);
     }
 
     /**
@@ -244,7 +244,7 @@ class ConfigTest extends AbstractConfigTest
     /**
      * @covers \Phinx\Config\Config::setVersionOrder
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Invalid version_order configuration option: bad-order. Valid values: creation-time or start-time
+     * @expectedExceptionMessage Invalid version_order configuration option: bad-order. Valid values: creation or execution
      */
     public function testSetVersionOrderThrowsException()
     {
@@ -278,9 +278,9 @@ class ConfigTest extends AbstractConfigTest
             [
                 \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, true
             ],
-            'With Start Time Version Order' =>
+            'With Execution Time Version Order' =>
             [
-                \Phinx\Config\Config::VERSION_ORDER_START_TIME, false
+                \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, false
             ],
         ];
     }

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -226,7 +226,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getTargetFromDateThrowsExceptionDataProvider
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid date. Format is YYYYmmddHHiiss (with no mandatory part, but the missing part(s) must all be in the end of the date string)
+     * @expectedExceptionMessage Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].
      */
     public function testGetTargetFromDateThrowsException($invalidDate)
     {

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -31,6 +31,11 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
      */
     protected $output;
 
+    /**
+     * Default Test Environment
+     */
+    const DEFAULT_TEST_ENVIRONMENT = 'development';
+
     protected function setUp()
     {
         $this->config = new Config(array(
@@ -67,7 +72,8 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
-                    ->method('rollback');
+                    ->method('rollback')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, null, false, true);
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -75,7 +81,12 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
 
-        $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
+        $display = $commandTester->getDisplay();
+
+        $this->assertRegExp('/no environment specified/', $display);
+
+        // note that the default order is by creation-time
+        $this->assertRegExp('/ordering by creation-time/', $display);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -90,7 +101,8 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
-                    ->method('rollback');
+                    ->method('rollback')
+                    ->with('fakeenv', null, false, true);
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -112,7 +124,8 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
-                    ->method('rollback');
+                    ->method('rollback')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, null, false);
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -120,5 +133,138 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
         $this->assertRegExp('/using database development/', $commandTester->getDisplay());
+    }
+    
+    public function testStartTimeVersionOrder()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Rollback());
+
+        // setup dependencies
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub->expects($this->once())
+                    ->method('rollback')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, null, false, true);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
+        $this->assertRegExp('/ordering by start-time/', $commandTester->getDisplay());
+    }
+    
+    public function testWithDate()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+
+        $date = '20160101';
+        $target = '20160101000000';
+        $rollbackStub = $this->getMock('\Phinx\Console\Command\Rollback', array('getTargetFromDate'));
+        $rollbackStub->expects($this->once())
+                    ->method('getTargetFromDate')
+                    ->with($date)
+                    ->will($this->returnValue($target));
+
+        $application->add($rollbackStub);
+
+        // setup dependencies
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub->expects($this->once())
+                    ->method('rollback')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, $target, false, false);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '-d' => $date), array('decorated' => false));
+    }
+
+    /**
+     * @dataProvider getTargetFromDataProvider
+     */
+    public function testGetTargetFromDate($date, $expectedTarget)
+    {
+        $rollbackCommand = new Rollback();
+        $this->assertEquals($expectedTarget, $rollbackCommand->getTargetFromDate($date));
+    }
+
+    public function getTargetFromDataProvider()
+    {
+        return [
+            'Date with only year' => [
+                '2015', '20150101000000'
+            ],
+            'Date with year and month' => [
+                '201409', '20140901000000'
+            ],
+            'Date with year, month and day' => [
+                '20130517', '20130517000000'
+            ],
+            'Date with year, month, day and hour' => [
+                '2013051406', '20130514060000'
+            ],
+            'Date with year, month, day, hour and minutes' => [
+                '201305140647', '20130514064700'
+            ],
+            'Date with year, month, day, hour, minutes and seconds' => [
+                '20130514064726', '20130514064726'
+            ]
+        ];
+    }
+
+
+    /**
+     * @dataProvider getTargetFromDateThrowsExceptionDataProvider
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid date. Format is YYYYmmddHHiiss (with no mandatory part, but the missing part(s) must all be in the end of the date string)
+     */
+    public function testGetTargetFromDateThrowsException($invalidDate)
+    {
+        $rollbackCommand = new Rollback();
+        $rollbackCommand->getTargetFromDate($invalidDate);
+    }
+    
+    public function getTargetFromDateThrowsExceptionDataProvider()
+    {
+        return [
+            ['20'],
+            ['2015060522354698'],
+            ['invalid']
+        ];
+    }
+
+    public function testStarTimeVersionOrderWithDate()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Rollback());
+
+        // setup dependencies
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        $targetDate = '20150101';
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub->expects($this->once())
+                    ->method('rollback')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, '20150101000000', false, false);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '-d' => $targetDate), array('decorated' => false));
+        $this->assertRegExp('/ordering by start-time/', $commandTester->getDisplay());
     }
 }

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -85,8 +85,8 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         $this->assertRegExp('/no environment specified/', $display);
 
-        // note that the default order is by creation-time
-        $this->assertRegExp('/ordering by creation-time/', $display);
+        // note that the default order is by creation time
+        $this->assertRegExp('/ordering by creation time/', $display);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -141,7 +141,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $application->add(new Rollback());
 
         // setup dependencies
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command = $application->find('rollback');
 
@@ -156,7 +156,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
-        $this->assertRegExp('/ordering by start-time/', $commandTester->getDisplay());
+        $this->assertRegExp('/ordering by execution time/', $commandTester->getDisplay());
     }
     
     public function testWithDate()
@@ -249,7 +249,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $application->add(new Rollback());
 
         // setup dependencies
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command = $application->find('rollback');
 
@@ -265,6 +265,6 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '-d' => $targetDate), array('decorated' => false));
-        $this->assertRegExp('/ordering by start-time/', $commandTester->getDisplay());
+        $this->assertRegExp('/ordering by execution time/', $commandTester->getDisplay());
     }
 }

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -31,6 +31,11 @@ class StatusTest extends \PHPUnit_Framework_TestCase
      */
     protected $output;
 
+    /**
+     * Default Test Environment
+     */
+    const DEFAULT_TEST_ENVIRONMENT = 'development';
+
     protected function setUp()
     {
         $this->config = new Config(array(
@@ -68,6 +73,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('printStatus')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, null)
                     ->will($this->returnValue(0));
 
         $command->setConfig($this->config);
@@ -93,6 +99,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('printStatus')
+                    ->with('fakeenv', null)
                     ->will($this->returnValue(0));
 
         $command->setConfig($this->config);
@@ -117,6 +124,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
         $managerStub->expects($this->once())
                     ->method('printStatus')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, 'json')
                     ->will($this->returnValue(0));
 
         $command->setConfig($this->config);

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -87,8 +87,8 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $display = $commandTester->getDisplay();
         $this->assertRegExp('/no environment specified/', $display);
         
-        // note that the default order is by creation-time
-        $this->assertRegExp('/ordering by creation-time/', $display);
+        // note that the default order is by creation time
+        $this->assertRegExp('/ordering by creation time/', $display);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -141,7 +141,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/using format json/', $commandTester->getDisplay());
     }
 
-    public function testExecuteVersionOrderByStartTime()
+    public function testExecuteVersionOrderByExecutionTime()
     {
         $application = new PhinxApplication('testing');
         $application->add(new Status());
@@ -157,7 +157,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
                     ->with(self::DEFAULT_TEST_ENVIRONMENT, null)
                     ->will($this->returnValue(0));
 
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -169,6 +169,6 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
         $display = $commandTester->getDisplay();
         $this->assertRegExp('/no environment specified/', $display);
-        $this->assertRegExp('/ordering by start-time/', $display);
+        $this->assertRegExp('/ordering by execution time/', $display);
     }
 }

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -83,7 +83,12 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $return = $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
 
         $this->assertEquals(0, $return);
-        $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
+
+        $display = $commandTester->getDisplay();
+        $this->assertRegExp('/no environment specified/', $display);
+        
+        // note that the default order is by creation-time
+        $this->assertRegExp('/ordering by creation-time/', $display);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -134,5 +139,36 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $return = $commandTester->execute(array('command' => $command->getName(), '--format' => 'json'), array('decorated' => false));
         $this->assertEquals(0, $return);
         $this->assertRegExp('/using format json/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteVersionOrderByStartTime()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Status());
+
+        /** @var Status $command */
+        $command = $application->find('status');
+
+        // mock the manager class
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub->expects($this->once())
+                    ->method('printStatus')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, null)
+                    ->will($this->returnValue(0));
+
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $return = $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
+
+        $this->assertEquals(0, $return);
+
+        $display = $commandTester->getDisplay();
+        $this->assertRegExp('/no environment specified/', $display);
+        $this->assertRegExp('/ordering by start-time/', $display);
     }
 }

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -416,7 +416,20 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('varchar(255)', $rows[1]['Type']);
     }
 
-    public function testRenameColumn()
+    public function testAddStringColumnWithCustomCollation()
+    {
+        $table = new \Phinx\Db\Table('table_custom_collation', array('collation' => 'utf8_general_ci'), $this->adapter);
+        $table->save();
+        $this->assertFalse($table->hasColumn('string_collation_default'));
+        $this->assertFalse($table->hasColumn('string_collation_custom'));
+        $table->addColumn('string_collation_default', 'string', array())->save();
+        $table->addColumn('string_collation_custom', 'string', array('collation' => 'utf8mb4_unicode_ci'))->save();
+        $rows = $this->adapter->fetchAll('SHOW FULL COLUMNS FROM table_custom_collation');
+        $this->assertEquals('utf8_general_ci', $rows[1]['Collation']);
+        $this->assertEquals('utf8mb4_unicode_ci', $rows[2]['Collation']);
+    }
+
+public function testRenameColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
         $table->addColumn('column1', 'string')

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -30,4 +30,61 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
         $this->adapter->setSchemaTableName('schema_table_test');
         $this->assertEquals('schema_table_test', $this->adapter->getSchemaTableName());
     }
+    
+    /**
+     * @dataProvider getVersionLogDataProvider
+     */
+    public function testGetVersionLog($versionOrder, $expectedOrderBy)
+    {
+        $adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter', 
+            array(array('version_order' => $versionOrder)), '', true, true, true,
+            array('fetchAll', 'getSchemaTableName'));
+
+        $schemaTableName = 'log';
+        $adapter->expects($this->once())
+            ->method('getSchemaTableName')
+            ->will($this->returnValue($schemaTableName));
+
+        $mockRows = array (
+            array(
+                'version' => '20120508120534',
+                'key' => 'value'
+            ),
+            array(
+                'version' => '20130508120534',
+                'key' => 'value'
+            ),
+        );
+
+        $adapter->expects($this->once())
+            ->method('fetchAll')
+            ->with("SELECT * FROM $schemaTableName ORDER BY $expectedOrderBy")
+            ->will($this->returnValue($mockRows));
+
+        // we expect the mock rows but indexed by version creation time
+        $expected = array(
+            '20120508120534' => array(
+                'version' => '20120508120534',
+                'key' => 'value'
+            ),
+            '20130508120534' => array(
+                'version' => '20130508120534',
+                'key' => 'value'
+            ),
+        );
+
+        $this->assertEquals($expected, $adapter->getVersionLog());
+    }
+
+    public function getVersionLogDataProvider()
+    {
+        return array(
+            'With Creation Time Version Order' => array(
+                \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, 'version ASC'
+            ),
+            'With Start Time Version Order' => array(
+                \Phinx\Config\Config::VERSION_ORDER_START_TIME, 'start_time ASC, version ASC'
+            ),
+        );
+    }
 }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -82,8 +82,8 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
             'With Creation Time Version Order' => array(
                 \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, 'version ASC'
             ),
-            'With Start Time Version Order' => array(
-                \Phinx\Config\Config::VERSION_ORDER_START_TIME, 'start_time ASC, version ASC'
+            'With Execution Time Version Order' => array(
+                \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, 'start_time ASC, version ASC'
             ),
         );
     }

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -361,45 +361,12 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test that migrating to date chooses the correct migration to point to.
-     *
-     * @dataProvider rollbackToDateTimeDataProvider
-     */
-    public function testRollbackToDateTime($availableRollbacks, $dateString, $expectedRollback)
-    {
-        // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
-        $envStub->expects($this->any())
-                ->method('getVersions')
-                ->will($this->returnValue(array_keys($availableRollbacks)));
-
-        // stub manager
-        $config = new Config($this->getConfigArray());
-        $input = new ArrayInput([]);
-        $output = new StreamOutput(fopen('php://memory', 'a', false));
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array('rollback'), array($config, $input, $output));
- 
-        if (is_null($expectedRollback)) {
-            $managerStub->expects($this->never())
-                ->method('rollback');
-        } else {
-            $managerStub->expects($this->once())
-                ->method('rollback')
-                ->with($this->equalTo('mockenv'), $expectedRollback)
-                ->will($this->returnValue($availableRollbacks));
-        }
- 
-        $managerStub->setEnvironments(array('mockenv' => $envStub));
-        $managerStub->rollbackToDateTime('mockenv', new \DateTime($dateString));
-    }
-
-    /**
      * Test that rollbacking to version chooses the correct
      * migration to point to.
      *
-     * @dataProvider rollbackDataProvider
+     * @dataProvider rollbackToVersionDataProvider
      */
-    public function testRollback($availableRollbacks, $version, $expectedOutput)
+    public function testRollbackToVersion($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
@@ -412,7 +379,106 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
         if (is_null($expectedOutput)) {
-            $this->assertEquals("No migrations to rollback\n", $output);
+            $this->assertEquals("No migrations to rollback".PHP_EOL, $output);
+        } else {
+            if (is_string($expectedOutput)) {
+                $expectedOutput = [$expectedOutput];
+            }
+            
+            foreach ($expectedOutput as $expectedLine) {
+                $this->assertContains($expectedLine, $output);
+            }
+        }
+    }
+    
+    /**
+     * Test that rollbacking to date chooses the correct
+     * migration to point to.
+     *
+     * @dataProvider rollbackToDateDataProvider
+     */
+    public function testRollbackToDate($availableRollbacks, $version, $expectedOutput)
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->any())
+            ->method('getVersionLog')
+            ->will($this->returnValue($availableRollbacks));
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->rollback('mockenv', $version, false, false);
+        rewind($this->manager->getOutput()->getStream());
+        $output = stream_get_contents($this->manager->getOutput()->getStream());
+        if (is_null($expectedOutput)) {
+            $this->assertEquals("No migrations to rollback".PHP_EOL, $output);
+        } else {
+            if (is_string($expectedOutput)) {
+                $expectedOutput = [$expectedOutput];
+            }
+            
+            foreach ($expectedOutput as $expectedLine) {
+                $this->assertContains($expectedLine, $output);
+            }
+        }
+    }
+    
+    /**
+     * Test that rollbacking to version by start time chooses the correct
+     * migration to point to.
+     *
+     * @dataProvider rollbackToVersionByStartTimeDataProvider
+     */
+    public function testRollbackToVersionByStartTime($availableRollbacks, $version, $expectedOutput)
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->any())
+            ->method('getVersionLog')
+            ->will($this->returnValue($availableRollbacks));
+
+        // set the manager's config version order to start-time
+        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_START_TIME);
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->rollback('mockenv', $version);
+        rewind($this->manager->getOutput()->getStream());
+        $output = stream_get_contents($this->manager->getOutput()->getStream());
+
+        if (is_null($expectedOutput)) {
+            $this->assertEmpty($output);
+        } else {
+            if (is_string($expectedOutput)) {
+                $expectedOutput = [$expectedOutput];
+            }
+            
+            foreach ($expectedOutput as $expectedLine) {
+                $this->assertContains($expectedLine, $output);
+            }
+        }
+    }
+    
+    /**
+     * Test that rollbacking to date by start time chooses the correct
+     * migration to point to.
+     *
+     * @dataProvider rollbackToDateByStartTimeDataProvider
+     */
+    public function testRollbackToDateByStartTime($availableRollbacks, $date, $expectedOutput)
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->any())
+            ->method('getVersionLog')
+            ->will($this->returnValue($availableRollbacks));
+
+        // set the manager's config version order to start-time
+        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_START_TIME);
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->rollback('mockenv', $date, false, false);
+        rewind($this->manager->getOutput()->getStream());
+        $output = stream_get_contents($this->manager->getOutput()->getStream());
+
+        if (is_null($expectedOutput)) {
+            $this->assertEquals("No migrations to rollback".PHP_EOL, $output);
         } else {
             if (is_string($expectedOutput)) {
                 $expectedOutput = [$expectedOutput];
@@ -424,7 +490,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testRollbackWithSingleMigrationDoesNotFail()
+    public function testRollbackToVersionWithSingleMigrationDoesNotFail()
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
@@ -444,7 +510,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertNotContains('Undefined offset: -1', $output);
     }
 
-    public function testRollbackWithTwoMigrationsDoesNotRollbackBothMigrations()
+    public function testRollbackToVersionWithTwoMigrationsDoesNotRollbackBothMigrations()
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
@@ -477,6 +543,37 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that rollbacking last migration 
+     *
+     * @dataProvider rollbackLastDataProvider
+     */
+    public function testRollbackLast($availableRolbacks, $versionOrder, $expectedOutput)
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->any())
+            ->method('getVersionLog')
+            ->will($this->returnValue($availableRolbacks));
+
+        $this->manager->getConfig()->setVersionOrder($versionOrder);
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->rollback('mockenv', null);
+        rewind($this->manager->getOutput()->getStream());
+        $output = stream_get_contents($this->manager->getOutput()->getStream());
+        if (is_null($expectedOutput)) {
+            $this->assertEquals("No migrations to rollback".PHP_EOL, $output);
+        } else {
+            if (is_string($expectedOutput)) {
+                $expectedOutput = [$expectedOutput];
+            }
+            
+            foreach ($expectedOutput as $expectedLine) {
+                $this->assertContains($expectedLine, $output);
+            }
+        }
+    }
+
+    /**
      * Migration lists, dates, and expected migrations to point to.
      *
      * @return array
@@ -496,7 +593,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public function rollbackToDateTimeDataProvider()
+    public function rollbackToDateDataProvider()
     {
         return [
 
@@ -508,7 +605,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
                     ],
-                    '20130118', 
+                    '20130118000000', 
                     null
                 ],
             'Rollback to date of the most recent migration - no breakpoints set' => 
@@ -518,7 +615,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
                     ],
                     '20120116183504', 
-                    20120116183504
+                    null
                 ],
             'Rollback to date between 2 migrations - no breakpoints set' => 
                 [
@@ -527,7 +624,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
                     ],
                     '20120115', 
-                    20120111235330
+                    '== 20120116183504 TestMigration2: reverted'
                 ],
             'Rollback to date of the oldest migration - no breakpoints set' => 
                 [
@@ -536,7 +633,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
                     ],
                     '20120111235330', 
-                    20120111235330
+                    '== 20120116183504 TestMigration2: reverted'
                 ],
             'Rollback to date before all the migrations - no breakpoints set' => 
                 [
@@ -545,7 +642,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
                     ],
                     '20110115', 
-                    0
+                    ['== 20120116183504 TestMigration2: reverted', '== 20120111235330 TestMigration: reverted']
                 ],
 
             // Breakpoint set on first migration
@@ -556,7 +653,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
                     ],
-                    '20130118', 
+                    '20130118000000', 
                     null
                 ],
             'Rollback to date of the most recent migration - breakpoint set on first migration' => 
@@ -566,7 +663,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
                     ],
                     '20120116183504', 
-                    20120116183504
+                    null
                 ],
             'Rollback to date between 2 migrations - breakpoint set on first migration' => 
                 [
@@ -575,7 +672,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
                     ],
                     '20120115', 
-                    20120111235330
+                    '== 20120116183504 TestMigration2: reverted'
                 ],
             'Rollback to date of the oldest migration - breakpoint set on first migration' => 
                 [
@@ -584,7 +681,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
                     ],
                     '20120111235330', 
-                    20120111235330
+                    '== 20120116183504 TestMigration2: reverted'
                 ],
             'Rollback to date before all the migrations - breakpoint set on first migration' => 
                 [
@@ -593,7 +690,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
                     ],
                     '20110115', 
-                    0
+                    'Breakpoint reached. Further rollbacks inhibited.'
                 ],
 
             // Breakpoint set on last migration
@@ -604,7 +701,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
                     ],
-                    '20130118', 
+                    '20130118000000', 
                     null
                 ],
             'Rollback to date of the most recent migration - breakpoint set on last migration' => 
@@ -614,7 +711,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
                     ],
                     '20120116183504', 
-                    20120116183504
+                    null
                 ],
             'Rollback to date between 2 migrations - breakpoint set on last migration' => 
                 [
@@ -622,8 +719,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
                     ],
-                    '20120115', 
-                    20120111235330
+                    '20120115000000', 
+                    'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             'Rollback to date of the oldest migration - breakpoint set on last migration' => 
                 [
@@ -632,7 +729,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
                     ],
                     '20120111235330', 
-                    20120111235330
+                    'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             'Rollback to date before all the migrations - breakpoint set on last migration' => 
                 [
@@ -640,8 +737,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
                     ],
-                    '20110115', 
-                    0
+                    '20110115000000', 
+                    'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             
             // Breakpoint set on all migrations
@@ -652,7 +749,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
                     ],
-                    '20130118', 
+                    '20130118000000', 
                     null
                 ],
             'Rollback to date of the most recent migration - breakpoint set on all migrations' => 
@@ -662,7 +759,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
                     ],
                     '20120116183504', 
-                    20120116183504
+                    null
                 ],
             'Rollback to date between 2 migrations - breakpoint set on all migrations' => 
                 [
@@ -670,8 +767,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
                     ],
-                    '20120115', 
-                    20120111235330
+                    '20120115000000', 
+                    'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             'Rollback to date of the oldest migration - breakpoint set on all migrations' => 
                 [
@@ -680,7 +777,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
                     ],
                     '20120111235330', 
-                    20120111235330
+                    'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             'Rollback to date before all the migrations - breakpoint set on all migrations' => 
                 [
@@ -688,10 +785,247 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                         '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
                         '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
                     ],
-                    '20110115', 
-                    0
+                    '20110115000000', 
+                    'Breakpoint reached. Further rollbacks inhibited.'
                 ],
         ];
+    }
+
+    /**
+     * Migration lists, dates, and expected migration version to rollback to.
+     *
+     * @return array
+     */
+    public function rollbackToDateByStartTimeDataProvider()
+    {
+        return array(
+
+            // No breakpoints set
+
+            'Rollback to date later than all migration start times when they were created in a different order than they were executed - no breakpoints set' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    '20131212000000',
+                    null
+                ),
+            'Rollback to date earlier than all migration start times when they were created in a different order than they were executed - no breakpoints set' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    '20111212000000',
+                    ['== 20120111235330 TestMigration: reverted', '== 20120116183504 TestMigration2: reverted']
+                ),
+            'Rollback to start time of first created version which was the last to be executed - no breakpoints set' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    '20120120235330',
+                    null
+                ),
+            'Rollback to start time of second created version which was the first to be executed - no breakpoints set' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    '20120117183504',
+                    '== 20120111235330 TestMigration: reverted'
+                ),
+            'Rollback to date between the 2 migrations when they were created in a different order than they were executed - no breakpoints set' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    '20120118000000',
+                    '== 20120111235330 TestMigration: reverted'
+                ),
+            'Rollback the last executed migration when the migrations were created in a different order than they were executed - no breakpoints set' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    null,
+                    '== 20120111235330 TestMigration: reverted'
+                ),
+
+
+            // Breakpoint set on first/last created/executed migration
+
+            'Rollback to date later than all migration start times when they were created in a different order than they were executed - breakpoints set on first created (and last executed) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    '20131212000000',
+                    null
+                ),
+            'Rollback to date later than all migration start times when they were created in a different order than they were executed - breakpoints set on first executed (and last created) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    '20131212000000',
+                    null
+                ),
+            'Rollback to date earlier than all migration start times when they were created in a different order than they were executed - breakpoints set on first created (and last executed) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    '20111212000000',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ),
+            'Rollback to date earlier than all migration start times when they were created in a different order than they were executed - breakpoints set on first executed (and last created) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    '20111212000000',
+                    ['== 20120111235330 TestMigration: reverted', 'Breakpoint reached. Further rollbacks inhibited.']
+                ),
+            'Rollback to start time of first created version which was the last to be executed - breakpoints set on first created (and last executed) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    '20120120235330',
+                    null
+                ),
+            'Rollback to start time of first created version which was the last to be executed - breakpoints set on first executed (and last created) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    '20120120235330',
+                    null
+                ),
+            'Rollback to start time of second created version which was the first to be executed - breakpoints set on first created (and last executed) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    '20120117183504',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ),
+            'Rollback to start time of second created version which was the first to be executed - breakpoints set on first executed (and last created) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    '20120117183504',
+                    '== 20120111235330 TestMigration: reverted'
+                ),
+            'Rollback to date between the 2 migrations when they were created in a different order than they were executed - breakpoints set on first created (and last executed) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    '20120118000000',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ),
+            'Rollback to date between the 2 migrations when they were created in a different order than they were executed - breakpoints set on first executed (and last created) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    '20120118000000',
+                    '== 20120111235330 TestMigration: reverted'
+                ),
+            'Rollback the last executed migration when the migrations were created in a different order than they were executed - breakpoints set on first created (and last executed) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    null,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ),
+            'Rollback the last executed migration when the migrations were created in a different order than they were executed - breakpoints set on first executed (and last created) migration' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ),
+                    null,
+                    '== 20120111235330 TestMigration: reverted'
+                ),
+
+            // Breakpoint set on all migration
+
+            'Rollback to date later than all migration start times when they were created in a different order than they were executed - breakpoints set on all migrations' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    '20131212000000',
+                    null
+                ),
+            'Rollback to date earlier than all migration start times when they were created in a different order than they were executed - breakpoints set on all migrations' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    '20111212000000',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ),
+            'Rollback to start time of first created version which was the last to be executed - breakpoints set on all migrations' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    '20120120235330',
+                    null
+                ),
+            'Rollback to start time of second created version which was the first to be executed - breakpoints set on all migrations' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    '20120117183504',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ),
+            'Rollback to date between the 2 migrations when they were created in a different order than they were executed - breakpoints set on all migrations' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    '20120118000000',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ),
+            'Rollback the last executed migration when the migrations were created in a different order than they were executed - breakpoints set on all migrations' => 
+                array(
+                    array(
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ),
+                    null,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ),
+        );
     }
 
     /**
@@ -699,7 +1033,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public function rollbackDataProvider()
+    public function rollbackToVersionDataProvider()
     {
         return [
 
@@ -935,6 +1269,571 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     'Target version (20111225000000) not found',
                 ]
         ];
+    }
+
+    public function rollbackToVersionByStartTimeDataProvider()
+    {
+        return [
+
+            // No breakpoints set
+
+            'Rollback to first created version with was also the first to be executed - no breakpoints set' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                    ],
+                    '20120111235330',
+                    '== 20120116183504 TestMigration2: reverted'
+                ],
+            'Rollback to last created version which was also the last to be executed - no breakpoints set' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                    ],
+                    '20120116183504',
+                    'No migrations to rollback'
+                ],
+            'Rollback all versions (ie. rollback to version 0) - no breakpoints set' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                    ],
+                    '0',
+                    ['== 20120111235330 TestMigration: reverted', '== 20120116183504 TestMigration2: reverted']
+                ],
+            'Rollback to second created version which was the first to be executed - no breakpoints set' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'end_time' => '2012-01-10 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                    ],
+                    '20120116183504',
+                    '== 20120111235330 TestMigration: reverted'
+                ],
+            'Rollback to first created version which was the second to be executed - no breakpoints set' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ],
+                    '20120111235330',
+                    'No migrations to rollback'
+                ],
+            'Rollback last executed version which was also the last created version - no breakpoints set' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                    ],
+                    null,
+                    '== 20120116183504 TestMigration2: reverted'
+                ],
+            'Rollback last executed version which was the first created version - no breakpoints set' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ],
+                    null,
+                    '== 20120111235330 TestMigration: reverted'
+                ],
+            'Rollback to non-existing version - no breakpoints set' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+            'Rollback to missing version - no breakpoints set' => 
+                [
+                    [
+                        '20111225000000' => array('version' => '20111225000000', 'start_time' => '2011-12-25 00:00:00', 'end_time' => '2011-12-25 00:00:00', 'breakpoint' => 0),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+
+            // Breakpoint set on first migration
+
+            'Rollback to first created version with was also the first to be executed - breakpoint set on first (executed and created) migration' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                    ],
+                    '20120111235330',
+                    '== 20120116183504 TestMigration2: reverted'
+                ],
+            'Rollback to last created version which was also the last to be executed - breakpoint set on first (executed and created) migration' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                    ],
+                    '20120116183504',
+                    'No migrations to rollback'
+                ],
+            'Rollback all versions (ie. rollback to version 0) - breakpoint set on first (executed and created) migration' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                    ],
+                    '0',
+                    ['== 20120116183504 TestMigration2: reverted', 'Breakpoint reached. Further rollbacks inhibited.']
+                ],
+            'Rollback to second created version which was the first to be executed - breakpoint set on first executed migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'end_time' => '2012-01-10 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                    ],
+                    '20120116183504',
+                    '== 20120111235330 TestMigration: reverted'
+                ],
+            'Rollback to second created version which was the first to be executed - breakpoint set on first created migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'end_time' => '2012-01-10 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                    ],
+                    '20120116183504',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to first created version which was the second to be executed - breakpoint set on first executed migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ],
+                    '20120111235330',
+                    'No migrations to rollback'
+                ],
+            'Rollback to first created version which was the second to be executed - breakpoint set on first created migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ],
+                    '20120111235330',
+                    'No migrations to rollback'
+                ],
+            'Rollback last executed version which was also the last created version - breakpoint set on first (executed and created) migration' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                    ],
+                    null,
+                    '== 20120116183504 TestMigration2: reverted'
+                ],
+            'Rollback last executed version which was the first created version - breakpoint set on first executed migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ],
+                    null,
+                    '== 20120111235330 TestMigration: reverted'
+                ],
+            'Rollback last executed version which was the first created version - breakpoint set on first created migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ],
+                    null,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to non-existing version - breakpoint set on first executed migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+            'Rollback to missing version - breakpoint set on first executed migration' => 
+                [
+                    [
+                        '20111225000000' => array('version' => '20111225000000', 'start_time' => '2011-12-25 00:00:00', 'end_time' => '2011-12-25 00:00:00', 'breakpoint' => 1),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+
+            // Breakpoint set on last migration
+
+            'Rollback to first created version with was also the first to be executed - breakpoint set on last (executed and created) migration' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                    ],
+                    '20120111235330',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to last created version which was also the last to be executed - breakpoint set on last (executed and created) migration' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                    ],
+                    '20120116183504',
+                    'No migrations to rollback'
+                ],
+            'Rollback all versions (ie. rollback to version 0) - breakpoint set on last (executed and created) migration' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                    ],
+                    '0',
+                    ['Breakpoint reached. Further rollbacks inhibited.']
+                ],
+            'Rollback to second created version which was the first to be executed - breakpoint set on last executed migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'end_time' => '2012-01-10 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                    ],
+                    '20120116183504',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to second created version which was the first to be executed - breakpoint set on last created migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'end_time' => '2012-01-10 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                    ],
+                    '20120116183504',
+                    '== 20120111235330 TestMigration: reverted'
+                ],
+            'Rollback to first created version which was the second to be executed - breakpoint set on last executed migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ],
+                    '20120111235330',
+                    'No migrations to rollback'
+                ],
+            'Rollback to first created version which was the second to be executed - breakpoint set on last created migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ],
+                    '20120111235330',
+                    'No migrations to rollback'
+                ],
+            'Rollback last executed version which was also the last created version - breakpoint set on last (executed and created) migration' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 0),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                    ],
+                    null,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback last executed version which was the first created version - breakpoint set on last executed migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ],
+                    null,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback last executed version which was the first created version - breakpoint set on last created migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 0),
+                    ],
+                    null,
+                    '== 20120111235330 TestMigration: reverted'
+                ],
+            'Rollback to non-existing version - breakpoint set on last executed migration' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+            'Rollback to missing version - breakpoint set on last executed migration' => 
+                [
+                    [
+                        '20111225000000' => array('version' => '20111225000000', 'start_time' => '2011-12-25 00:00:00', 'end_time' => '2011-12-25 00:00:00', 'breakpoint' => 0),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 0),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+
+            // Breakpoint set on all migrations
+
+            'Rollback to first created version with was also the first to be executed - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                    ],
+                    '20120111235330',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to last created version which was also the last to be executed - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                    ],
+                    '20120116183504',
+                    'No migrations to rollback'
+                ],
+            'Rollback all versions (ie. rollback to version 0) - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                    ],
+                    '0',
+                    ['Breakpoint reached. Further rollbacks inhibited.']
+                ],
+            'Rollback to second created version which was the first to be executed - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'end_time' => '2012-01-10 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                    ],
+                    '20120116183504',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to first created version which was the second to be executed - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ],
+                    '20120111235330',
+                    'No migrations to rollback'
+                ],
+            'Rollback last executed version which was also the last created version - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'end_time' => '2012-01-12 23:53:30', 'breakpoint' => 1),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                    ],
+                    null,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback last executed version which was the first created version - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ],
+                    null,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to non-existing version - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+            'Rollback to missing version - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20111225000000' => array('version' => '20111225000000', 'start_time' => '2011-12-25 00:00:00', 'end_time' => '2011-12-25 00:00:00', 'breakpoint' => 1),
+                        '20120116183504' => array('version' => '20120116183504', 'start_time' => '2012-01-17 18:35:04', 'end_time' => '2012-01-17 18:35:04', 'breakpoint' => 1),
+                        '20120111235330' => array('version' => '20120111235330', 'start_time' => '2012-01-20 23:53:30', 'end_time' => '2012-01-20 23:53:30', 'breakpoint' => 1),
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+        ];
+    }
+
+    /**
+     * Migration lists, version order configuration and expected output.
+     *
+     * @return array
+     */
+    public function rollbackLastDataProvider()
+    {
+        return [
+
+            // No breakpoints set
+
+            'Rollback to last migration with creation time version ordering - no breakpoints set' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 0],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    '== 20120116183504 TestMigration2: reverted'
+                ],
+            
+            'Rollback to last migration with start time version ordering - no breakpoints set' => 
+                [
+                    [
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    '== 20120111235330 TestMigration: reverted'
+                ],
+            
+            'Rollback to last migration with missing last migration and creation time version ordering - no breakpoints set' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 0],
+                        '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    '== 20120116183504 TestMigration2: reverted'
+                ],
+            
+            'Rollback to last migration with missing last migration and start time version ordering - no breakpoints set' => 
+                [
+                    [
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
+                        '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    '== 20120111235330 TestMigration: reverted'
+                ],
+            
+            // Breakpoint set on last migration
+
+            'Rollback to last migration with creation time version ordering - breakpoint set on last created migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            
+            'Rollback to last migration with creation time version ordering - breakpoint set on last executed migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 0],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    '== 20120116183504 TestMigration2: reverted'
+                ],
+
+            'Rollback to last migration with missing last migration and creation time version ordering - breakpoint set on last non-missing created migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
+                        '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            
+            'Rollback to last migration with missing last migration and start time version ordering - breakpoint set on last non-missing executed migration' => 
+                [
+                    [
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
+                        '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            
+            'Rollback to last migration with missing last migration and creation time version ordering - breakpoint set on missing migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 0],
+                        '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    '== 20120116183504 TestMigration2: reverted'
+                ],
+            
+            'Rollback to last migration with missing last migration and start time version ordering - breakpoint set on missing migration' => 
+                [
+                    [
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
+                        '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    '== 20120111235330 TestMigration: reverted'
+                ],
+            
+            // Breakpoint set on all migrations
+
+            'Rollback to last migration with creation time version ordering - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            
+            'Rollback to last migration with creation time version ordering - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+
+            'Rollback to last migration with missing last migration and creation time version ordering - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-16 18:35:04', 'breakpoint' => 1],
+                        '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            
+            'Rollback to last migration with missing last migration and start time version ordering - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 1],
+                        '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
+                        '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
+                    ],
+                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            ];
     }
 
     public function testExecuteSeedWorksAsExpected()

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -412,22 +412,22 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $configWithNoVersionOrder = new Config($configArray);
 
         $configArray['version_order'] = Config::VERSION_ORDER_CREATION_TIME;
-        $configWithCreationTimeVersionOrder = new Config($configArray);
+        $configWithCreationVersionOrder = new Config($configArray);
 
-        $configArray['version_order'] = Config::VERSION_ORDER_START_TIME;
-        $configWithStartTimeVersionOrder = new Config($configArray);
+        $configArray['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
+        $configWithExecutionVersionOrder = new Config($configArray);
 
         return [
             'With the default version order' => [
                 $configWithNoVersionOrder,
                 ' Status  <info>[Migration ID]</info>  Started              Finished             Migration Name '
             ],
-            'With the creation-time version order' => [
-                $configWithCreationTimeVersionOrder,
+            'With the creation version order' => [
+                $configWithCreationVersionOrder,
                 ' Status  <info>[Migration ID]</info>  Started              Finished             Migration Name '
             ],
-            'With the start-time version order' => [
-                $configWithStartTimeVersionOrder,
+            'With the execution version order' => [
+                $configWithExecutionVersionOrder,
                 ' Status  Migration ID    <info>[Started          ]</info>  Finished             Migration Name '
             ]
         ];
@@ -579,12 +579,12 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
     
     /**
-     * Test that rollbacking to version by start time chooses the correct
+     * Test that rollbacking to version by execution time chooses the correct
      * migration to point to.
      *
-     * @dataProvider rollbackToVersionByStartTimeDataProvider
+     * @dataProvider rollbackToVersionByExecutionTimeDataProvider
      */
-    public function testRollbackToVersionByStartTime($availableRollbacks, $version, $expectedOutput)
+    public function testRollbackToVersionByExecutionTime($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
@@ -592,8 +592,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
-        // set the manager's config version order to start-time
-        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_START_TIME);
+        // set the manager's config version order to execution time
+        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv', $version);
         rewind($this->manager->getOutput()->getStream());
@@ -613,12 +613,12 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
     
     /**
-     * Test that rollbacking to date by start time chooses the correct
+     * Test that rollbacking to date by execution time chooses the correct
      * migration to point to.
      *
-     * @dataProvider rollbackToDateByStartTimeDataProvider
+     * @dataProvider rollbackToDateByExecutionTimeDataProvider
      */
-    public function testRollbackToDateByStartTime($availableRollbacks, $date, $expectedOutput)
+    public function testRollbackToDateByExecutionTime($availableRollbacks, $date, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
@@ -626,8 +626,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
-        // set the manager's config version order to start-time
-        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_START_TIME);
+        // set the manager's config version order to execution time
+        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv', $date, false, false);
         rewind($this->manager->getOutput()->getStream());
@@ -952,7 +952,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public function rollbackToDateByStartTimeDataProvider()
+    public function rollbackToDateByExecutionTimeDataProvider()
     {
         return array(
 
@@ -1427,7 +1427,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function rollbackToVersionByStartTimeDataProvider()
+    public function rollbackToVersionByExecutionTimeDataProvider()
     {
         return [
 
@@ -1848,13 +1848,13 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     '== 20120116183504 TestMigration2: reverted'
                 ],
             
-            'Rollback to last migration with start time version ordering - no breakpoints set' => 
+            'Rollback to last migration with execution time version ordering - no breakpoints set' => 
                 [
                     [
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120111235330 TestMigration: reverted'
                 ],
             
@@ -1869,14 +1869,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     '== 20120116183504 TestMigration2: reverted'
                 ],
             
-            'Rollback to last migration with missing last migration and start time version ordering - no breakpoints set' => 
+            'Rollback to last migration with missing last migration and execution time version ordering - no breakpoints set' => 
                 [
                     [
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120111235330 TestMigration: reverted'
                 ],
             
@@ -1913,14 +1913,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             
-            'Rollback to last migration with missing last migration and start time version ordering - breakpoint set on last non-missing executed migration' => 
+            'Rollback to last migration with missing last migration and execution time version ordering - breakpoint set on last non-missing executed migration' => 
                 [
                     [
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             
@@ -1935,14 +1935,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     '== 20120116183504 TestMigration2: reverted'
                 ],
             
-            'Rollback to last migration with missing last migration and start time version ordering - breakpoint set on missing migration' => 
+            'Rollback to last migration with missing last migration and execution time version ordering - breakpoint set on missing migration' => 
                 [
                     [
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120111235330 TestMigration: reverted'
                 ],
             
@@ -1979,14 +1979,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             
-            'Rollback to last migration with missing last migration and start time version ordering - breakpoint set on all migrations' => 
+            'Rollback to last migration with missing last migration and execution time version ordering - breakpoint set on all migrations' => 
                 [
                     [
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 1],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             ];

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -361,29 +361,66 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test that migrating by date chooses the correct migration to point to.
+     * Test that migrating to date chooses the correct migration to point to.
      *
-     * @dataProvider rollbackDateDataProvider
+     * @dataProvider rollbackToDateTimeDataProvider
      */
-    public function testRollbacksByDate(array $availableRollbacks, $dateString, $expectedRollback, $message)
+    public function testRollbackToDateTime($availableRollbacks, $dateString, $expectedRollback)
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->any())
+                ->method('getVersions')
+                ->will($this->returnValue(array_keys($availableRollbacks)));
+
+        // stub manager
+        $config = new Config($this->getConfigArray());
+        $input = new ArrayInput([]);
+        $output = new StreamOutput(fopen('php://memory', 'a', false));
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array('rollback'), array($config, $input, $output));
+ 
+        if (is_null($expectedRollback)) {
+            $managerStub->expects($this->never())
+                ->method('rollback');
+        } else {
+            $managerStub->expects($this->once())
+                ->method('rollback')
+                ->with($this->equalTo('mockenv'), $expectedRollback)
+                ->will($this->returnValue($availableRollbacks));
+        }
+ 
+        $managerStub->setEnvironments(array('mockenv' => $envStub));
+        $managerStub->rollbackToDateTime('mockenv', new \DateTime($dateString));
+    }
+
+    /**
+     * Test that rollbacking to version chooses the correct
+     * migration to point to.
+     *
+     * @dataProvider rollbackDataProvider
+     */
+    public function testRollback($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
         $envStub->expects($this->any())
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
-        $envStub->expects($this->any())
-                ->method('getVersions')
-                ->will($this->returnValue(array_keys($availableRollbacks)));
 
         $this->manager->setEnvironments(array('mockenv' => $envStub));
-        $this->manager->rollbackToDateTime('mockenv', new \DateTime($dateString));
+        $this->manager->rollback('mockenv', $version);
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
-        if (is_null($expectedRollback)) {
-            $this->assertEmpty($output, $message);
+        if (is_null($expectedOutput)) {
+            $this->assertEquals("No migrations to rollback\n", $output);
         } else {
-            $this->assertRegExp($expectedRollback, $output, $message);
+            if (is_string($expectedOutput)) {
+                $expectedOutput = [$expectedOutput];
+            }
+            
+            foreach ($expectedOutput as $expectedLine) {
+                $this->assertContains($expectedLine, $output);
+            }
         }
     }
 
@@ -455,205 +492,448 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Migration lists, dates, and expected migrations to point to.
+     * Migration lists, dates, and expected migration version to rollback to.
      *
      * @return array
      */
-    public function rollbackDateDataProvider()
+    public function rollbackToDateTimeDataProvider()
     {
         return [
 
             // No breakpoints set
 
-            [
+            'Rollback to date which is later than all migrations - no breakpoints set' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20130118', 
+                    null
                 ],
-                '20130118',
-                null,
-                'Failed to rollback 0 migrations when rollback to date is later than all migrations - no breakpoints set',
-            ],
-            [
+            'Rollback to date of the most recent migration - no breakpoints set' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20120116183504', 
+                    20120116183504
                 ],
-                '20120116183504',
-                '`No migrations to rollback`',
-                'Failed to rollback 0 migrations when rollback to date is the most recent migration - no breakpoints set',
-            ],
-            [
+            'Rollback to date between 2 migrations - no breakpoints set' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20120115', 
+                    20120111235330
                 ],
-                '20120115',
-                '`20120116183504`',
-                'Failed to rollback 1 migration when rollback date is between 2 migrations - no breakpoints set',
-            ],
-            [
+            'Rollback to date of the oldest migration - no breakpoints set' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20120111235330', 
+                    20120111235330
                 ],
-                '20120111235330',
-                '`20120116183504`',
-                'Failed to rollback 1 migration when rollback datetime is the one of the migrations - no breakpoints set',
-            ],
-            [
+            'Rollback to date before all the migrations - no breakpoints set' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20110115', 
+                    0
                 ],
-                '20110115',
-                '`20120111235330`',
-                'Failed to rollback all the migrations when the rollback date is before all the migrations - no breakpoints set',
-            ],
 
             // Breakpoint set on first migration
 
-            [
+            'Rollback to date which is later than all migrations - breakpoint set on first migration' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20130118', 
+                    null
                 ],
-                '20130118',
-                null,
-                'Failed to rollback 0 migrations when rollback to date is later than all migrations - breakpoint set on first migration',
-            ],
-            [
+            'Rollback to date of the most recent migration - breakpoint set on first migration' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20120116183504', 
+                    20120116183504
                 ],
-                '20120116183504',
-                '`No migrations to rollback`',
-                'Failed to rollback 0 migrations when rollback to date is the most recent migration - breakpoint set on first migration',
-            ],
-            [
+            'Rollback to date between 2 migrations - breakpoint set on first migration' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20120115', 
+                    20120111235330
                 ],
-                '20120115',
-                '`20120116183504`',
-                'Failed to rollback 1 migration when rollback date is between 2 migrations - breakpoint set on first migration',
-            ],
-            [
+            'Rollback to date of the oldest migration - breakpoint set on first migration' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20120111235330', 
+                    20120111235330
                 ],
-                '20120111235330',
-                '`20120116183504`',
-                'Failed to rollback 1 migration when rollback datetime is the one of the migrations - breakpoint set on first migration',
-            ],
-            [
+            'Rollback to date before all the migrations - breakpoint set on first migration' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20110115', 
+                    0
                 ],
-                '20110115',
-                '`(?!.*20120111235330.*)20120116183504.*Breakpoint reached.*`s',
-                'Failed to rollback 1 migration when the rollback date is before all the migrations and breakpoint set on first migration',
-            ],
 
             // Breakpoint set on last migration
 
-            [
+            'Rollback to date which is later than all migrations - breakpoint set on last migration' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20130118', 
+                    null
                 ],
-                '20130118',
-                null,
-                'Failed to rollback 0 migrations when rollback to date is later than all migrations - breakpoint set on last migration',
-            ],
-            [
+            'Rollback to date of the most recent migration - breakpoint set on last migration' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20120116183504', 
+                    20120116183504
                 ],
-                '20120116183504',
-                '`No migrations to rollback`',
-                'Failed to rollback 0 migrations when rollback to date is the most recent migration - breakpoint set on last migration',
-            ],
-            [
+            'Rollback to date between 2 migrations - breakpoint set on last migration' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20120115', 
+                    20120111235330
                 ],
-                '20120115',
-                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
-                'Failed to rollback 0 migrations when rollback date is between 2 migrations and breakpoint set on last migration',
-            ],
-            [
+            'Rollback to date of the oldest migration - breakpoint set on last migration' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20120111235330', 
+                    20120111235330
                 ],
-                '20120111235330',
-                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
-                'Failed to rollback 0 migrations when rollback datetime is the one of the migrations and breakpoint set on last migration',
-            ],
-            [
+            'Rollback to date before all the migrations - breakpoint set on last migration' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20110115', 
+                    0
                 ],
-                '20110115',
-                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
-                'Failed to rollback 0 migrations when the rollback date is before all the migrations and breakpoint set on last migration',
-            ],
+            
+            // Breakpoint set on all migrations
 
-            // Breakpoint set on all migration
+            'Rollback to date which is later than all migrations - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20130118', 
+                    null
+                ],
+            'Rollback to date of the most recent migration - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20120116183504', 
+                    20120116183504
+                ],
+            'Rollback to date between 2 migrations - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20120115', 
+                    20120111235330
+                ],
+            'Rollback to date of the oldest migration - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20120111235330', 
+                    20120111235330
+                ],
+            'Rollback to date before all the migrations - breakpoint set on all migrations' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20110115', 
+                    0
+                ],
+        ];
+    }
 
-            [
+    /**
+     * Migration lists, dates, and expected output.
+     *
+     * @return array
+     */
+    public function rollbackDataProvider()
+    {
+        return [
+
+            // No breakpoints set
+
+            'Rollback to one of the versions - no breakpoints set' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20120111235330', 
+                    '== 20120116183504 TestMigration2: reverted'
                 ],
-                '20130118',
-                null,
-                'Failed to rollback 0 migrations when rollback to date is later than all migrations - breakpoint set on all migrations',
-            ],
-            [
+            'Rollback to the latest version - no breakpoints set' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20120116183504', 
+                    null
                 ],
-                '20120116183504',
-                '`No migrations to rollback`',
-                'Failed to rollback 0 migrations when rollback to date is the most recent migration - breakpoint set on all migrations',
-            ],
-            [
+            'Rollback all versions (ie. rollback to version 0) - no breakpoints set' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '0',
+                    ['== 20120111235330 TestMigration: reverted', '== 20120116183504 TestMigration2: reverted']
                 ],
-                '20120115',
-                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
-                'Failed to rollback 0 migrations when rollback date is between 2 migrations and breakpoint set on all migrations',
-            ],
-            [
+            'Rollback last version - no breakpoints set' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    null, 
+                    '== 20120116183504 TestMigration2: reverted',
                 ],
-                '20120111235330',
-                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
-                'Failed to rollback 0 migrations when rollback datetime is the one of the migrations and breakpoint set on all migrations',
-            ],
-            [
+            'Rollback to non-existing version - no breakpoints set' => 
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
                 ],
-                '20110115',
-                '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
-                'Failed to rollback 0 migrations when the rollback date is before all the migrations and breakpoint set on all migrations',
-            ],
+            'Rollback to missing version - no breakpoints set' => 
+                [
+                    [
+                        '20111225000000' => ['version' => '20111225000000', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20111225000000', 
+                    'Target version (20111225000000) not found',
+                ],
+            
+            // Breakpoint set on first migration
+
+            'Rollback to one of the versions - breakpoint set on first migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20120111235330', 
+                    '== 20120116183504 TestMigration2: reverted'
+                ],
+            'Rollback to the latest version - breakpoint set on first migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20120116183504', 
+                    null
+                ],
+            'Rollback all versions (ie. rollback to version 0) - breakpoint set on first migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '0',
+                    '== 20120116183504 TestMigration2: reverted'
+                ],
+            'Rollback last version - breakpoint set on first migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    null, 
+                    '== 20120116183504 TestMigration2: reverted',
+                ],
+            'Rollback to non-existing version - breakpoint set on first migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+            'Rollback to missing version - breakpoint set on first migration' => 
+                [
+                    [
+                        '20111225000000' => ['version' => '20111225000000', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 0],
+                    ],
+                    '20111225000000', 
+                    'Target version (20111225000000) not found',
+                ],
+            
+            // Breakpoint set on last migration
+
+            'Rollback to one of the versions - breakpoint set on last migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20120111235330', 
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to the latest version - breakpoint set on last migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20120116183504', 
+                    null
+                ],
+            'Rollback all versions (ie. rollback to version 0) - breakpoint set on last migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '0',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback last version - breakpoint set on last migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    null, 
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to non-existing version - breakpoint set on last migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+            'Rollback to missing version - breakpoint set on last migration' => 
+                [
+                    [
+                        '20111225000000' => ['version' => '20111225000000', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 0],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20111225000000', 
+                    'Target version (20111225000000) not found',
+                ],
+            
+            // Breakpoint set on all migrations
+
+            'Rollback to one of the versions - breakpoint set on last migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20120111235330', 
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to the latest version - breakpoint set on last migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20120116183504', 
+                    null
+                ],
+            'Rollback all versions (ie. rollback to version 0) - breakpoint set on last migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '0',
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback last version - breakpoint set on last migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    null, 
+                    'Breakpoint reached. Further rollbacks inhibited.'
+                ],
+            'Rollback to non-existing version - breakpoint set on last migration' => 
+                [
+                    [
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20121225000000', 
+                    'Target version (20121225000000) not found',
+                ],
+            'Rollback to missing version - breakpoint set on last migration' => 
+                [
+                    [
+                        '20111225000000' => ['version' => '20111225000000', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120111235330' => ['version' => '20120111235330', 'migration_name' => '', 'breakpoint' => 1],
+                        '20120116183504' => ['version' => '20120116183504', 'migration_name' => '', 'breakpoint' => 1],
+                    ],
+                    '20111225000000', 
+                    'Target version (20111225000000) not found',
+                ]
         ];
     }
 

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -592,8 +592,15 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
-        // set the manager's config version order to execution time
-        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
+        // get a manager with a config whose version order is set to execution time
+        $configArray = $this->getConfigArray();
+        $configArray['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $config = new Config($configArray);
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
+        $this->output->setDecorated(false);
+        
+        $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv', $version);
         rewind($this->manager->getOutput()->getStream());
@@ -626,8 +633,15 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
-        // set the manager's config version order to execution time
-        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
+        // get a manager with a config whose version order is set to execution time
+        $configArray = $this->getConfigArray();
+        $configArray['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $config = new Config($configArray);
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
+        $this->output->setDecorated(false);
+        
+        $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv', $date, false, false);
         rewind($this->manager->getOutput()->getStream());
@@ -711,7 +725,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRolbacks));
 
-        $this->manager->getConfig()->setVersionOrder($versionOrder);
+        // get a manager with a config whose version order is set to execution time
+        $configArray = $this->getConfigArray();
+        $configArray['version_order'] = $versionOrder;
+        $config = new Config($configArray);
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
+        $this->output->setDecorated(false);
+        $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv', null);
         rewind($this->manager->getOutput()->getStream());


### PR DESCRIPTION
A new Configuration option named `version_order` was added. Its possible values are:

* `creation-time` (the default): causes the Rollback and Status commands to order the executed migrations by their creation times (aka Migration IDs or Names).
* `start-time`: causes the Rollback and Status commands to order the executed migrations by their start times (aka Execution Times).

This means that when invoking the Rollback command:
    
- With a `start-time` version order, the last executed migration will be rollbacked.
- With a `start-time` version order and a `-d (date)` option, the migration start times will be used to determine the target version to rollback to. In other words, all migrations which were executed after that date will be rollbacked.
- With a `start-time` version order and a `-t (target version)` option, all migrations which were executed after the target version was executed will be rollbacked.

In terms of testing:

- The old `testRollbacksByDate` test was renamed to `testRollbackToDateTime` and turned into a unit test, ensuring the `rollback` method is called with the right target version. A new `testRollback` was added which ensures the correct output of the rollback operation (as was being done in the old `testRollbacksByDate` test).
- More test cases were added.
- General test improvements were done (like adding the expected arguments to the underlying Manager calls in `RollbackTest` and `StatusTest`.

Other notes:
- The old `rollback` and `rollbackToDateTime` methods were merged into a single `rollback` method that handles all cases and version orders.
- This PR replaces https://github.com/robmorgan/phinx/pull/745.