### PR TITLE
Constructor declaration removed from ConfigInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version History
 
+**0.7.x-dev** (***)
+
+* New features
+  * [#885](https://github.com/robmorgan/phinx/pull/885) Add `collation` and `encoding` options for MySQL text and char columns
+
 **0.6.x-dev** (***)
 
 * Documentation updates

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -711,6 +711,15 @@ Option   Description
 signed   enable or disable the ``unsigned`` option *(only applies to MySQL)*
 ======== ===========
 
+For ``string`` and ``text`` columns:
+
+========= ===========
+Option    Description
+========= ===========
+collation set collation that differs from table defaults *(only applies to MySQL)*
+encoding  set character set that differs from table defaults *(only applies to MySQL)*
+========= ===========
+
 For foreign key definitions:
 
 ====== ===========

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -37,14 +37,6 @@ namespace Phinx\Config;
 interface ConfigInterface extends \ArrayAccess
 {
     /**
-     * Class Constructor
-     *
-     * @param array $configArray Config Array
-     * @param string $configFilePath Optional File Path
-     */
-    public function __construct(array $configArray, $configFilePath = null);
-
-    /**
      * Returns the configuration for each environment.
      *
      * This method returns <code>null</code> if no environments exist.

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -1034,6 +1034,8 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
         if (($values = $column->getValues()) && is_array($values)) {
             $def .= "('" . implode("', '", $values) . "')";
         }
+        $def .= $column->getEncoding() ? ' CHARACTER SET ' . $column->getEncoding() : '';
+        $def .= $column->getCollation() ? ' COLLATE ' . $column->getCollation() : '';
         $def .= (!$column->isSigned() && isset($this->signedColumnTypes[$column->getType()])) ? ' unsigned' : '' ;
         $def .= ($column->isNull() == false) ? ' NOT NULL' : ' NULL';
         $def .= ($column->isIdentity()) ? ' AUTO_INCREMENT' : '';

--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -28,6 +28,8 @@
  */
 namespace Phinx\Db\Table;
 
+use Phinx\Db\Adapter\AdapterInterface;
+
 /**
  *
  * This object is based loosely on: http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html.
@@ -103,6 +105,16 @@ class Column
      * @var array
      */
     protected $properties = array();
+
+    /**
+     * @var string
+     */
+    protected $collation;
+
+    /**
+     * @var string
+     */
+    protected $encoding;
 
     /**
      * @var array
@@ -486,6 +498,72 @@ class Column
     }
 
     /**
+     * Sets the column collation.
+     *
+     * @param string $collation
+     *
+     * @throws \UnexpectedValueException If collation not allowed for type
+     * @return $this
+     */
+    public function setCollation($collation)
+    {
+        $allowedTypes = array(
+            AdapterInterface::PHINX_TYPE_CHAR,
+            AdapterInterface::PHINX_TYPE_STRING,
+            AdapterInterface::PHINX_TYPE_TEXT,
+        );
+        if (!in_array($this->getType(), $allowedTypes))
+            throw new \UnexpectedValueException('Collation may be set only for types: ' . implode(', ', $allowedTypes));
+
+        $this->collation = $collation;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column collation.
+     *
+     * @return string
+     */
+    public function getCollation()
+    {
+        return $this->collation;
+    }
+
+    /**
+     * Sets the column character set.
+     *
+     * @param string $encoding
+     *
+     * @throws \UnexpectedValueException If character set not allowed for type
+     * @return $this
+     */
+    public function setEncoding($encoding)
+    {
+        $allowedTypes = array(
+            AdapterInterface::PHINX_TYPE_CHAR,
+            AdapterInterface::PHINX_TYPE_STRING,
+            AdapterInterface::PHINX_TYPE_TEXT,
+        );
+        if (!in_array($this->getType(), $allowedTypes))
+            throw new \UnexpectedValueException('Character set may be set only for types: ' . implode(', ', $allowedTypes));
+
+        $this->encoding = $encoding;
+
+        return $this;
+    }
+
+    /**
+     * Gets the column character set.
+     *
+     * @return string
+     */
+    public function getEncoding()
+    {
+        return $this->encoding;
+    }
+
+    /**
      * Gets all allowed options. Each option must have a corresponding `setFoo` method.
      *
      * @return array
@@ -506,6 +584,8 @@ class Column
             'timezone',
             'properties',
             'values',
+            'collation',
+            'encoding',
         );
     }
 

--- a/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/MysqlAdapterTest.php
@@ -416,7 +416,20 @@ class MysqlAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('varchar(255)', $rows[1]['Type']);
     }
 
-    public function testRenameColumn()
+    public function testAddStringColumnWithCustomCollation()
+    {
+        $table = new \Phinx\Db\Table('table_custom_collation', array('collation' => 'utf8_general_ci'), $this->adapter);
+        $table->save();
+        $this->assertFalse($table->hasColumn('string_collation_default'));
+        $this->assertFalse($table->hasColumn('string_collation_custom'));
+        $table->addColumn('string_collation_default', 'string', array())->save();
+        $table->addColumn('string_collation_custom', 'string', array('collation' => 'utf8mb4_unicode_ci'))->save();
+        $rows = $this->adapter->fetchAll('SHOW FULL COLUMNS FROM table_custom_collation');
+        $this->assertEquals('utf8_general_ci', $rows[1]['Collation']);
+        $this->assertEquals('utf8mb4_unicode_ci', $rows[2]['Collation']);
+    }
+
+public function testRenameColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);
         $table->addColumn('column1', 'string')


### PR DESCRIPTION
Having constructor declared in \Phinx\Config\ConfigInterface makes it unreasonably hard to make non file based configurations. I have a Silex project with its own configuration infrastructure and I want to use Phinx as the migration tool. My plan is to inherit from `\Symfony\Component\Console\Application` roughly like this:

```php
class MyPhinxApplication extends \Phinx\Console\PhinxApplication
{
    public function __construct(MySilexApplication $app)
    {
        parent::__construct();
        $config = new MyConfigAdapter($app);
        foreach ($this->all() as $command) {
            if ($command instanceof Phinx\Console\Command\AbstractCommand) {
                $command->setConfig($config);
            }
        }
    }

}

class MyConfigAdapter implements \Phinx\Config\ConfigInterface
{
    public function __construct(MySilexApplication $app)
    {
        // here i can extract whatever i need from my Silex app
    }
    ...
}
```

The constructor declaration effectively prevents me from doing this, instead i have to fake the `$configArray` and `$configFilePath`, and inject my Silex app through a setter.