### PR TITLE
When setting options as a non-associative array, Column fails with "Call to undefined method Phinx\Db\Table\Column::set0()"

### DIFF
--- a/src/Phinx/Db/Table/Column.php
+++ b/src/Phinx/Db/Table/Column.php
@@ -538,7 +538,7 @@ class Column
                 $option = $aliasOptions[$option];
             }
 
-            if (!in_array($option, $validOptions)) {
+            if (!in_array($option, $validOptions, true)) {
                 throw new \RuntimeException(sprintf('"%s" is not a valid column option.', $option));
             }
 

--- a/src/Phinx/Db/Table/ForeignKey.php
+++ b/src/Phinx/Db/Table/ForeignKey.php
@@ -216,8 +216,8 @@ class ForeignKey
         // Valid Options
         $validOptions = array('delete', 'update', 'constraint');
         foreach ($options as $option => $value) {
-            if (!in_array($option, $validOptions)) {
-                throw new \RuntimeException('\'' . $option . '\' is not a valid foreign key option.');
+            if (!in_array($option, $validOptions, true)) {
+                throw new \RuntimeException(sprintf('"%s" is not a valid foreign key option.', $option));
             }
 
             // handle $options['delete'] as $options['update']

--- a/src/Phinx/Db/Table/Index.php
+++ b/src/Phinx/Db/Table/Index.php
@@ -165,8 +165,8 @@ class Index
         // Valid Options
         $validOptions = array('type', 'unique', 'name', 'limit');
         foreach ($options as $option => $value) {
-            if (!in_array($option, $validOptions)) {
-                throw new \RuntimeException('\'' . $option . '\' is not a valid index option.');
+            if (!in_array($option, $validOptions, true)) {
+                throw new \RuntimeException(sprintf('"%s" is not a valid index option.', $option));
             }
 
             // handle $options['unique']

--- a/tests/Phinx/Db/Table/ColumnTest.php
+++ b/tests/Phinx/Db/Table/ColumnTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Test\Phinx\Db\Table;
+
+use Phinx\Db\Table\Column;
+
+class ColumnTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage "0" is not a valid column option.
+     */
+    public function testSetOptionThrowsExceptionIfOptionIsNotString()
+    {
+        $column = new Column();
+        $column->setOptions(['identity']);
+    }
+}

--- a/tests/Phinx/Db/Table/ForeignKeyTest.php
+++ b/tests/Phinx/Db/Table/ForeignKeyTest.php
@@ -87,4 +87,13 @@ class ForeignKeyTest extends \PHPUnit_Framework_TestCase
             array('Set_nuLL',            ForeignKey::SET_NULL),
         );
     }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage "0" is not a valid foreign key option.
+     */
+    public function testSetOptionThrowsExceptionIfOptionIsNotString()
+    {
+        $this->fk->setOptions(['update']);
+    }
 }

--- a/tests/Phinx/Db/Table/IndexTest.php
+++ b/tests/Phinx/Db/Table/IndexTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Test\Phinx\Db\Table;
+
+use Phinx\Db\Table\Index;
+
+class IndexTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage "0" is not a valid index option.
+     */
+    public function testSetOptionThrowsExceptionIfOptionIsNotString()
+    {
+        $column = new Index();
+        $column->setOptions(['type']);
+    }
+}


### PR DESCRIPTION
This check makes sure the developer gets an appropriate message.