### PR TITLE
Getter should match setter. \Phinx\Console\Command\Create.php:21 …

### DIFF
--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -113,6 +113,13 @@ interface ConfigInterface extends \ArrayAccess
      *
      * @return string|false
      */
-     public function getTemplateClass();
+    public function getTemplateClass();
 
+    /**
+     * Gets the base class name for migrations.
+     *
+     * @param boolean $dropNamespace Return the base migration class name without the namespace.
+     * @return string
+     */
+    public function getMigrationBaseClassName($dropNamespace = true);
 }

--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -117,7 +117,7 @@ abstract class AbstractCommand extends Command
     /**
      * Gets the config.
      *
-     * @return Config
+     * @return ConfigInterface
      */
     public function getConfig()
     {


### PR DESCRIPTION
…uses getMigrationBaseClassName() so it is added to the interface