### PR TITLE
Added mention to removeIndexByName()

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -1091,6 +1091,9 @@ call this method for each index.
             {
                 $table = $this->table('users');
                 $table->removeIndex(array('email'));
+                
+                // alternatively, you can delete an index by its name, ie:
+                $table->removeIndexByName('idx_users_email');
             }
 
             /**


### PR DESCRIPTION
Only `removeIndex()` was mentioned in the docs. 

It took me quite a while to figure out that it expected the field names (and not the index names), so I'm adding the reference.