### PR TITLE
Close #938. Rollback target uses migration name

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -119,20 +119,21 @@ parameter or ``-t`` for short.
 
 .. code-block:: bash
 
-        $ phinx rollback -e development -t 20120103083322
+        $ phinx rollback -e development -t MyNewMigration
 
-Specifying 0 as the target version will revert all migrations.
+Specifying all as the target version will revert all migrations. This also
+works if specifying 0.
 
 .. code-block:: bash
 
-        $ phinx rollback -e development -t 0
+        $ phinx rollback -e development -t all
 
 If a breakpoint is set, blocking further rollbacks, you can override the
 breakpoint using the ``--force`` parameter or ``-f`` for short.
 
 .. code-block:: bash
 
-        $ phinx rollback -e development -t 0 -f
+        $ phinx rollback -e development -t all -f
 
 The Status Command
 ------------------

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -119,21 +119,21 @@ parameter or ``-t`` for short.
 
 .. code-block:: bash
 
-        $ phinx rollback -e development -t MyNewMigration
+        $ phinx rollback -e development -t 20120103083322
 
-Specifying all as the target version will revert all migrations. This also
-works if specifying 0.
+Specifying 0 as the target version will revert all migrations. This also
+works if specifying all.
 
 .. code-block:: bash
 
-        $ phinx rollback -e development -t all
+        $ phinx rollback -e development -t 0
 
 If a breakpoint is set, blocking further rollbacks, you can override the
 breakpoint using the ``--force`` parameter or ``-f`` for short.
 
 .. code-block:: bash
 
-        $ phinx rollback -e development -t all -f
+        $ phinx rollback -e development -t 0 -f
 
 The Status Command
 ------------------

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -392,17 +392,8 @@ class Manager
             // Get the migration before the last run migration
             $prev = count($versions) - 2;
             $version =  $prev < 0 ? 0 : $versions[$prev];
-        } elseif ($version === 'all' || $version === '0') {
+        } elseif ($version === 'all' || $version == 0) {
             $version = 0;
-        } else {
-            // Array of migration names
-            $migrationNames = array_map(function ($item) { return $item['migration_name']; }, $versionLog);
-
-            // Try to find a migration id with the supplied version name
-            $found = array_search($version, $migrationNames);
-            if ($found !== false) {
-                $version = $found;
-            }
         }
 
         // Check the target version exists

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -368,7 +368,7 @@ class Manager
      * Rollback an environment to the specified version.
      *
      * @param string $environment Environment
-     * @param int $version
+     * @param int|string $version
      * @param bool $force
      * @return void
      */
@@ -392,13 +392,16 @@ class Manager
             // Get the migration before the last run migration
             $prev = count($versions) - 2;
             $version =  $prev < 0 ? 0 : $versions[$prev];
+        } elseif ($version === 'all' || $version === '0') {
+            $version = 0;
         } else {
-            // Get the first migration number
-            $first = $versions[0];
+            // Array of migration names
+            $migrationNames = array_map(function ($item) { return $item['migration_name']; }, $versionLog);
 
-            // If the target version is before the first migration, revert all migrations
-            if ($version < $first) {
-                $version = 0;
+            // Try to find a migration id with the supplied version name
+            $found = array_search($version, $migrationNames);
+            if ($found !== false) {
+                $version = $found;
             }
         }
 

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -467,8 +467,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration2'],
                 ],
                 '20130118',
                 null,
@@ -476,8 +476,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120116183504',
                 '`No migrations to rollback`',
@@ -485,8 +485,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120115',
                 '`20120116183504`',
@@ -494,8 +494,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120111235330',
                 '`20120116183504`',
@@ -503,8 +503,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration2'],
                 ],
                 '20110115',
                 '`20120111235330`',
@@ -515,8 +515,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration2'],
                 ],
                 '20130118',
                 null,
@@ -524,8 +524,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120116183504',
                 '`No migrations to rollback`',
@@ -533,8 +533,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120115',
                 '`20120116183504`',
@@ -542,8 +542,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120111235330',
                 '`20120116183504`',
@@ -551,8 +551,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration2'],
                 ],
                 '20110115',
                 '`(?!.*20120111235330.*)20120116183504.*Breakpoint reached.*`s',
@@ -563,8 +563,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration2'],
                 ],
                 '20130118',
                 null,
@@ -572,8 +572,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120116183504',
                 '`No migrations to rollback`',
@@ -581,8 +581,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120115',
                 '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
@@ -590,8 +590,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120111235330',
                 '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
@@ -599,8 +599,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 0, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration2'],
                 ],
                 '20110115',
                 '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
@@ -611,8 +611,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration2'],
                 ],
                 '20130118',
                 null,
@@ -620,8 +620,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120116183504',
                 '`No migrations to rollback`',
@@ -629,8 +629,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120115',
                 '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
@@ -638,8 +638,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration2'],
                 ],
                 '20120111235330',
                 '`(?!.*20120116183504.*).*Breakpoint reached.*`s',
@@ -647,8 +647,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ],
             [
                 [
-                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1],
-                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1],
+                    '20120111235330' => ['version' => '20120111235330', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration'],
+                    '20120116183504' => ['version' => '20120116183504', 'migration' => '', 'breakpoint' => 1, 'migration_name' => 'TestMigration2'],
                 ],
                 '20110115',
                 '`(?!.*20120116183504.*).*Breakpoint reached.*`s',


### PR DESCRIPTION
Since the -d and -t are so similar, this changes the functionality of -t to use the migration name as specified when creating a migration, rather than an arbitrary integer. This accounts for a typo entered with the -t option causing all migrations to rollback.