### PR TITLE
Fix deprecated use of getMock() on tests (II)

### DIFF
--- a/tests/Phinx/Console/Command/CreateTest.php
+++ b/tests/Phinx/Console/Command/CreateTest.php
@@ -81,7 +81,9 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -106,7 +108,9 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -128,7 +132,9 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
 
         $this->config['templates'] = array(
             'file' => 'MyTemplate',
@@ -188,7 +194,9 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
 
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;
@@ -250,7 +258,9 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
 
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;
@@ -311,7 +321,9 @@ class CreateTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('create');
 
         /** @var Manager $managerStub mock the manager class */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
 
         foreach ($config as $key => $value) {
             $this->config[$key] = $value;

--- a/tests/Phinx/Console/Command/MigrateTest.php
+++ b/tests/Phinx/Console/Command/MigrateTest.php
@@ -65,7 +65,9 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $this->input, $this->output]);
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs([$this->config, $this->input, $this->output])
+             ->getMock();
         $managerStub->expects($this->once())
                     ->method('migrate');
 
@@ -89,7 +91,9 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $this->input, $this->output]);
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs([$this->config, $this->input, $this->output])
+             ->getMock();
         $managerStub->expects($this->any())
                     ->method('migrate');
 
@@ -113,7 +117,9 @@ class MigrateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', [], [$this->config, $this->input, $this->output]);
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs([$this->config, $this->input, $this->output])
+             ->getMock();
         $managerStub->expects($this->once())
                     ->method('migrate');
 

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -65,7 +65,9 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
         $managerStub->expects($this->once())
                     ->method('rollback');
 
@@ -88,7 +90,9 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
         $managerStub->expects($this->once())
                     ->method('rollback');
 
@@ -110,7 +114,9 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
         $managerStub->expects($this->once())
                     ->method('rollback');
 

--- a/tests/Phinx/Console/Command/SeedCreateTest.php
+++ b/tests/Phinx/Console/Command/SeedCreateTest.php
@@ -70,7 +70,9 @@ class SeedCreateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -94,7 +96,9 @@ class SeedCreateTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);

--- a/tests/Phinx/Console/Command/SeedRunTest.php
+++ b/tests/Phinx/Console/Command/SeedRunTest.php
@@ -66,7 +66,9 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
         $managerStub->expects($this->once())
                     ->method('seed')->with($this->identicalTo('development'), $this->identicalTo(null));
 
@@ -89,7 +91,9 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
         $managerStub->expects($this->any())
                     ->method('migrate');
 
@@ -111,7 +115,9 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
         $managerStub->expects($this->once())
                     ->method('seed');
 
@@ -133,7 +139,9 @@ class SeedRunTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
         $managerStub->expects($this->exactly(3))
                     ->method('seed')->withConsecutive(
                         array($this->identicalTo('development'), $this->identicalTo('One')),

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -65,7 +65,9 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
         $managerStub->expects($this->once())
                     ->method('printStatus')
                     ->will($this->returnValue(0));
@@ -90,7 +92,9 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
         $managerStub->expects($this->once())
                     ->method('printStatus')
                     ->will($this->returnValue(0));
@@ -114,7 +118,9 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+             ->setConstructorArgs(array($this->config, $this->input, $this->output))
+             ->getMock();
         $managerStub->expects($this->once())
                     ->method('printStatus')
                     ->will($this->returnValue(0));

--- a/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
+++ b/tests/Phinx/Db/Adapter/AdapterFactoryTest.php
@@ -90,7 +90,9 @@ class AdapterFactoryTest extends \PHPUnit_Framework_TestCase
 
     private function getAdapterMock()
     {
-        return $this->getMock('Phinx\Db\Adapter\AdapterInterface', array());
+        return $this->getMockBuilder('Phinx\Db\Adapter\AdapterInterface')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
     }
 
     public function testGetWrapper()

--- a/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/ProxyAdapterTest.php
@@ -18,7 +18,9 @@ class ProxyAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $stub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $stub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
 
         $this->adapter = new ProxyAdapter($stub);
     }

--- a/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/TablePrefixAdapterTest.php
@@ -26,7 +26,9 @@ class TablePrefixAdapterTest extends \PHPUnit_Framework_TestCase
             'table_suffix' => '_suf',
         );
 
-        $this->mock = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $this->mock = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
 
         $this->mock
             ->expects($this->any())

--- a/tests/Phinx/Db/TableTest.php
+++ b/tests/Phinx/Db/TableTest.php
@@ -169,7 +169,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testChangeColumn()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $adapterStub->expects($this->once())
                     ->method('changeColumn');
         $newColumn = new \Phinx\Db\Table\Column();
@@ -180,7 +182,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testChangeColumnWithoutAColumnObject()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $adapterStub->expects($this->once())
                     ->method('changeColumn');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
@@ -190,7 +194,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testDropForeignKey()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $adapterStub->expects($this->once())
                     ->method('dropForeignKey');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
@@ -200,7 +206,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testGetColumns()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $adapterStub->expects($this->once())
                     ->method('getColumns');
 
@@ -210,7 +218,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function testInsert()
     {
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $data = [
             'column1' => 'value1',
@@ -225,7 +235,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function testInsertSaveData()
     {
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $data = [
             [
@@ -257,7 +269,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testRemoveColumn()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $adapterStub->expects($this->once())
                     ->method('dropColumn');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
@@ -267,7 +281,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testRemoveIndex()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $adapterStub->expects($this->once())
                     ->method('dropIndex');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
@@ -277,7 +293,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testRemoveIndexByName()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $adapterStub->expects($this->once())
                     ->method('dropIndexByName');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
@@ -287,7 +305,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function testRenameColumn()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $adapterStub->expects($this->once())
                     ->method('renameColumn');
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
@@ -296,7 +316,9 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
     public function testResetAfterAddingData()
     {
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\MysqlAdapter', [], [[]]);
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\MysqlAdapter')
+			->setConstructorArgs(array(array()))
+			->getMock();
         $table = new \Phinx\Db\Table('ntable', [], $adapterStub);
         $columns = ["column1"];
         $data = [["value1"]];

--- a/tests/Phinx/Migration/AbstractMigrationTest.php
+++ b/tests/Phinx/Migration/AbstractMigrationTest.php
@@ -27,7 +27,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
 
         // test methods
         $this->assertNull($migrationStub->getAdapter());
@@ -41,7 +43,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub output
-        $outputStub = $this->getMock('\Symfony\Component\Console\Output\OutputInterface', array(), array(array()));
+        $outputStub = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
 
         // test methods
         $this->assertNull($migrationStub->getOutput());
@@ -52,7 +56,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testGetInputMethodWithInjectedInput()
     {
         // stub input
-        $inputStub = $this->getMock('\Symfony\Component\Console\Input\InputInterface', array(), array(array()));
+        $inputStub = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
 
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0, $inputStub, null));
@@ -65,7 +71,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     public function testGetOutputMethodWithInjectedOutput()
     {
         // stub output
-        $outputStub = $this->getMock('\Symfony\Component\Console\Output\OutputInterface', array(), array(array()));
+        $outputStub = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
 
         // stub migration
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0, null, $outputStub));
@@ -95,7 +103,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('execute')
                     ->will($this->returnValue(2));
@@ -110,7 +120,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('query')
                     ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
@@ -125,7 +137,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
         $adapterStub->expects($this->once())
                     ->method('fetchRow')
                     ->will($this->returnValue(array('0' => 'bar', 'foo' => 'bar')));
@@ -140,7 +154,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
         $adapterStub->expects($this->once())
                     ->method('fetchAll')
                     ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
@@ -155,7 +171,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
         $adapterStub->expects($this->once())
                     ->method('insert');
 
@@ -171,7 +189,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
         $adapterStub->expects($this->once())
                     ->method('createDatabase')
                     ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
@@ -186,7 +206,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
         $adapterStub->expects($this->once())
                     ->method('dropDatabase')
                     ->will($this->returnValue(array(array('0' => 'bar', 'foo' => 'bar'))));
@@ -201,7 +223,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
         $adapterStub->expects($this->once())
                     ->method('hasTable')
                     ->will($this->returnValue(true));
@@ -216,7 +240,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
         $migrationStub->setAdapter($adapterStub);
 
         $this->assertTrue($migrationStub->table('test_table') instanceof Table);
@@ -228,7 +254,9 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
         $migrationStub = $this->getMockForAbstractClass('\Phinx\Migration\AbstractMigration', array(0));
 
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+            ->setConstructorArgs(array(array()))
+            ->getMock();
         $adapterStub->expects($this->once())
                     ->method('dropTable');
 

--- a/tests/Phinx/Migration/Manager/EnvironmentTest.php
+++ b/tests/Phinx/Migration/Manager/EnvironmentTest.php
@@ -106,7 +106,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
     public function testCurrentVersion()
     {
-        $stub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $stub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
         $stub->expects($this->any())
              ->method('getVersions')
              ->will($this->returnValue(array('20110301080000')));
@@ -119,7 +121,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testExecutingAMigrationUp()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('migrated')
                     ->will($this->returnArgument(0));
@@ -127,7 +131,13 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->environment->setAdapter($adapterStub);
 
         // up
-        $upMigration = $this->getMock('\Phinx\Migration\AbstractMigration', array('up'), array('20110301080000'));
+        $upMigration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+             ->setMethods(array('up'))
+             ->setConstructorArgs(array('20110301080000'))
+             ->getMock();
+        $envStub = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
         $upMigration->expects($this->once())
                     ->method('up');
 
@@ -137,7 +147,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testExecutingAMigrationDown()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('migrated')
                     ->will($this->returnArgument(0));
@@ -145,7 +157,10 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->environment->setAdapter($adapterStub);
 
         // down
-        $downMigration = $this->getMock('\Phinx\Migration\AbstractMigration', array('down'), array('20110301080000'));
+        $downMigration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+             ->setMethods(array('down'))
+             ->setConstructorArgs(array('20110301080000'))
+             ->getMock();
         $downMigration->expects($this->once())
                       ->method('down');
 
@@ -155,7 +170,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testExecutingAMigrationWithTransactions()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('beginTransaction');
 
@@ -169,7 +186,10 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->environment->setAdapter($adapterStub);
 
         // migrate
-        $migration = $this->getMock('\Phinx\Migration\AbstractMigration', array('up'), array('20110301080000'));
+        $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+             ->setMethods(array('up'))
+             ->setConstructorArgs(array('20110301080000'))
+             ->getMock();
         $migration->expects($this->once())
                   ->method('up');
 
@@ -179,7 +199,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testExecutingAChangeMigrationUp()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('migrated')
                     ->will($this->returnArgument(0));
@@ -187,7 +209,10 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->environment->setAdapter($adapterStub);
 
         // migration
-        $migration = $this->getMock('\Phinx\Migration\AbstractMigration', array('change'), array('20130301080000'));
+        $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+             ->setMethods(array('change'))
+             ->setConstructorArgs(array('20130301080000'))
+             ->getMock();
         $migration->expects($this->once())
                   ->method('change');
 
@@ -197,7 +222,9 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testExecutingAChangeMigrationDown()
     {
         // stub adapter
-        $adapterStub = $this->getMock('\Phinx\Db\Adapter\PdoAdapter', array(), array(array()));
+        $adapterStub = $this->getMockBuilder('\Phinx\Db\Adapter\PdoAdapter')
+             ->setConstructorArgs(array(array()))
+             ->getMock();
         $adapterStub->expects($this->once())
                     ->method('migrated')
                     ->will($this->returnArgument(0));
@@ -205,7 +232,10 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->environment->setAdapter($adapterStub);
 
         // migration
-        $migration = $this->getMock('\Phinx\Migration\AbstractMigration', array('change'), array('20130301080000'));
+        $migration = $this->getMockBuilder('\Phinx\Migration\AbstractMigration')
+             ->setMethods(array('change'))
+             ->setConstructorArgs(array('20130301080000'))
+             ->getMock();
         $migration->expects($this->once())
                   ->method('change');
 

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -81,7 +81,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethod()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
                 ->will($this->returnValue(
@@ -119,7 +121,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithBreakpointSet()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
                 ->will($this->returnValue(
@@ -156,7 +160,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithNoMigrations()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
 
         // override the migrations directory to an empty one
         $configArray = $this->getConfigArray();
@@ -177,7 +183,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithMissingMigrations()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
                 ->will($this->returnValue(
@@ -215,7 +223,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithMissingMigrationsAndBreakpointSet()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
                 ->will($this->returnValue(
@@ -254,7 +264,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithDownMigrations()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
                 ->will($this->returnValue(array(
@@ -340,7 +352,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testMigrationsByDate(array $availableMigrations, $dateString, $expectedMigration, $message)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         if (is_null($expectedMigration)) {
             $envStub->expects($this->never())
                     ->method('getVersions');
@@ -368,7 +382,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbacksByDate(array $availableRollbacks, $dateString, $expectedRollback, $message)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
@@ -390,7 +406,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbackWithSingleMigrationDoesNotFail()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $envStub->expects($this->any())
                 ->method('getVersionLog')
                 ->will($this->returnValue([
@@ -410,7 +428,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbackWithTwoMigrationsDoesNotRollbackBothMigrations()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $envStub->expects($this->any())
                 ->method('getVersionLog')
                 ->will(
@@ -660,7 +680,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testExecuteSeedWorksAsExpected()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->seed('mockenv');
         rewind($this->manager->getOutput()->getStream());
@@ -673,7 +695,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testExecuteASingleSeedWorksAsExpected()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->seed('mockenv', 'UserSeeder');
         rewind($this->manager->getOutput()->getStream());
@@ -688,7 +712,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testExecuteANonExistentSeedWorksAsExpected()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+                ->setConstructorArgs(array('mockenv', array()))
+                ->getMock();
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->seed('mockenv', 'NonExistentSeeder');
         rewind($this->manager->getOutput()->getStream());


### PR DESCRIPTION
Come from: https://github.com/robmorgan/phinx/pull/928
I don't know if I did the rebase correctly (not an expert on Github)...
Regards!
