### PR TITLE
Adding hint on migration name in CamelCase

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -52,7 +52,7 @@ class Create extends AbstractCommand
 
         $this->setName('create')
             ->setDescription('Create a new migration')
-            ->addArgument('name', InputArgument::REQUIRED, 'What is the name of the migration?')
+            ->addArgument('name', InputArgument::REQUIRED, 'What is the name of the migration (in CamelCase)?')
             ->setHelp(sprintf(
                 '%sCreates a new database migration%s',
                 PHP_EOL,


### PR DESCRIPTION
Nothing much to say besides I get annoyed as I never remember if the migrations should be snake_case as the file or CamelCase as the class. A tip about that on the help could be useful, instead of hitting the errorwall :)
