### PR TITLE
Fix for Config::getMigrationBaseClassName

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -250,7 +250,7 @@ class Config implements ConfigInterface
     {
         $className = !isset($this->values['migration_base_class']) ? 'Phinx\Migration\AbstractMigration' : $this->values['migration_base_class'];
 
-        return $dropNamespace ? substr(strrchr($className, '\\'), 1) : $className;
+        return $dropNamespace ? substr(strrchr($className, '\\'), 1) ?: $className : $className;
     }
 
     /**

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -208,4 +208,28 @@ class ConfigTest extends AbstractConfigTest
         $config = new \Phinx\Config\Config(array());
         $this->assertEquals('db/seeds', $config->getSeedPath());
     }
+
+    /**
+     * Checks if base class is returned correctly when specified without
+     * a namespace.
+     *
+     * @covers \Phinx\Config\Config::getMigrationBaseClassName
+     */
+    public function testGetMigrationBaseClassNameNoNamespace()
+    {
+        $config = new Config(array('migration_base_class' => 'BaseMigration'));
+        $this->assertEquals('BaseMigration', $config->getMigrationBaseClassName());
+    }
+
+    /**
+     * Checks if base class is returned correctly when specified without
+     * a namespace.
+     *
+     * @covers \Phinx\Config\Config::getMigrationBaseClassName
+     */
+    public function testGetMigrationBaseClassNameNoNamespaceNoDrop()
+    {
+        $config = new Config(array('migration_base_class' => 'BaseMigration'));
+        $this->assertEquals('BaseMigration', $config->getMigrationBaseClassName(false));
+    }
 }


### PR DESCRIPTION
Ran into an issue where if the `migration_base_class` option is specified without a namespace, the class name returned empty in the migration generation.