### PR TITLE
Reverse "fix .gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,8 @@ composer.lock
 tests/log
 
 # ignore core development artifacts
-db
-migrations
+./db
+./migrations
 
 # sphinx generates HTML files for the documentation here
 docs/_build


### PR DESCRIPTION
Changing the db and migrations directories to non-relative paths as per 89f4fa27b302a6234b9676fa2bce2af83198e1bd resulted in a user with `core.ignorecase=true` in his git config having issues with files and folders within his vendor folder to be ignored #965.