### PR TITLE
Unable to create log table in mysql version < 5.6 with NO_ZERO_DATE mode. Fixed.

### DIFF
--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -508,12 +508,11 @@ abstract class PdoAdapter implements AdapterInterface
 
             $table = new Table($this->getSchemaTableName(), $options, $this);
 
-            if ($this->getConnection()->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'mysql'
-                && version_compare($this->getConnection()->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.6.0', '>=')) {
+            if ($this->getConnection()->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'mysql') {
                 $table->addColumn('version', 'biginteger', array('limit' => 14))
                       ->addColumn('migration_name', 'string', array('limit' => 100, 'default' => null, 'null' => true))
-                      ->addColumn('start_time', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
-                      ->addColumn('end_time', 'timestamp', array('default' => 'CURRENT_TIMESTAMP'))
+                      ->addColumn('start_time', 'timestamp', array('default' => null, 'null' => true))
+                      ->addColumn('end_time', 'timestamp', array('default' => null, 'null' => true))
                       ->addColumn('breakpoint', 'boolean', array('default' => false))
                       ->save();
             } else {


### PR DESCRIPTION
This fix solves the problem with the phinxlog table creation in MySQL versions earlier than 5.6.
To reproduce the problem:
1) Install MySQL 5.5.
2) Configure sql_mode this way: `sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES,NO_ZERO_DATE,NO_ZERO_IN_DATE`
3) Start a migration.

Note than in MySQL versions earlier than 5.6 you shouldn't create 2 columns with the `TIMESTAMP` type and `CURRENT_TIMESTAMP` as the default value.