### PR TITLE
Add gitattributes to exclude tests folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
Added `.gitattributes` to exclude the tests on export - e.g. when pulled in via composer.

