### PR TITLE
Update install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -18,12 +18,6 @@ To install Phinx, simply require it using Composer:
 
     php composer.phar require robmorgan/phinx
 
-Then run Composer:
-
-.. code-block:: bash
-
-    php composer.phar install --no-dev
-
 Create a folder in your project directory called ``migrations`` with adequate permissions.
 It is where your migration files will live and should be writable.
 


### PR DESCRIPTION
composer require automatically executes composer install.

example:
```
[~/scm] ➔ mkdir phinx
[~/scm] ➔ cd phinx
[~/scm/phinx] ➔ php composer.phar require robmorgan/phinx
Could not open input file: composer.phar
[~/scm/phinx] ➔  composer.phar require robmorgan/phinx
Using version ^0.6.5 for robmorgan/phinx
./composer.json has been created
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 8 installs, 0 updates, 0 removals
  - Installing symfony/yaml (v3.2.1) Loading from cache
  - Installing psr/log (1.0.2) Loading from cache
  - Installing symfony/debug (v3.2.1) Loading from cache
  - Installing symfony/polyfill-mbstring (v1.3.0) Loading from cache
  - Installing symfony/console (v3.2.1) Loading from cache
  - Installing symfony/filesystem (v3.2.1) Loading from cache
  - Installing symfony/config (v3.2.1) Loading from cache
  - Installing robmorgan/phinx (v0.6.5) Loading from cache
symfony/console suggests installing symfony/event-dispatcher ()
symfony/console suggests installing symfony/process ()
Writing lock file
Generating autoload files
[~/scm/phinx] ➔ 
```