### PR TITLE
Quote new column name in renameColumn in PostgresAdapter

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -411,7 +411,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
                 'ALTER TABLE %s RENAME COLUMN %s TO %s',
                 $this->quoteTableName($tableName),
                 $this->quoteColumnName($columnName),
-                $newColumnName
+                $this->quoteColumnName($newColumnName)
             )
         );
         $this->endCommandTimer();

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -360,6 +360,18 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->adapter->hasColumn('t', 'column2'));
     }
 
+    public function testRenameColumnIsCaseSensitive()
+    {
+        $table = new \Phinx\Db\Table('t', array(), $this->adapter);
+        $table->addColumn('columnOne', 'string')
+              ->save();
+        $this->assertTrue($this->adapter->hasColumn('t', 'columnOne'));
+        $this->assertFalse($this->adapter->hasColumn('t', 'columnTwo'));
+        $this->adapter->renameColumn('t', 'columnOne', 'columnTwo');
+        $this->assertFalse($this->adapter->hasColumn('t', 'columnOne'));
+        $this->assertTrue($this->adapter->hasColumn('t', 'columnTwo'));
+    }
+    
     public function testRenamingANonExistentColumn()
     {
         $table = new \Phinx\Db\Table('t', array(), $this->adapter);


### PR DESCRIPTION
The `$this->quoteColumnName` call is missing for `$newColumnName` in `PostgresAdapter`.

This results in bad behavior, for example `renameColumn('created_at', 'createdAt')` results in `createdat` column name in database.