### PR TITLE
Rollbacks by start time

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -127,12 +127,31 @@ Specifying 0 as the target version will revert all migrations.
 
         $ phinx rollback -e development -t 0
 
+To rollback all migrations to a specific date then use the ``--date``
+parameter or ``-d`` for short.
+
+.. code-block:: bash
+
+        $ phinx rollback -e development -d 2012
+        $ phinx rollback -e development -d 201201
+        $ phinx rollback -e development -d 20120103
+        $ phinx rollback -e development -d 2012010312
+        $ phinx rollback -e development -d 201201031205
+        $ phinx rollback -e development -d 20120103120530
+
 If a breakpoint is set, blocking further rollbacks, you can override the
 breakpoint using the ``--force`` parameter or ``-f`` for short.
 
 .. code-block:: bash
 
         $ phinx rollback -e development -t 0 -f
+
+.. note::
+
+        When rolling back, Phinx orders the executed migrations using 
+        the order specified in the ``version_order`` option of your 
+        ``phinx.yml`` file.
+        Please see the :doc:`Configuration <configuration>` chapter for more information.
 
 The Status Command
 ------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -307,5 +307,5 @@ Version Order
 When rolling back or printing the status of migrations, Phinx orders the executed migrations according to the 
 ``version_order`` option, which can have the following values:
 
-* ``creation-time`` (the default): migrations are ordered by their creation time, which is also part of their filename.
-* ``start-time``: migrations are ordered by their start time, also known as execution time.
+* ``creation`` (the default): migrations are ordered by their creation time, which is also part of their filename.
+* ``execution``: migrations are ordered by their execution time, also known as start time.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -300,3 +300,12 @@ The aliased classes will still be required to implement the ``Phinx\Migration\Cr
     aliases:
         permission: \Namespace\Migrations\PermissionMigrationTemplateGenerator
         view: \Namespace\Migrations\ViewMigrationTemplateGenerator
+
+Version Order
+------
+
+When rolling back or printing the status of migrations, Phinx orders the executed migrations according to the 
+``version_order`` option, which can have the following values:
+
+* ``creation-time`` (the default): migrations are ordered by their creation time, which is also part of their filename.
+* ``start-time``: migrations are ordered by their start time, also known as execution time.

--- a/phinx.yml
+++ b/phinx.yml
@@ -31,3 +31,5 @@ environments:
         pass: ''
         port: 3306
         charset: utf8
+
+version_order: creation-time

--- a/phinx.yml
+++ b/phinx.yml
@@ -32,4 +32,4 @@ environments:
         port: 3306
         charset: utf8
 
-version_order: creation-time
+version_order: creation

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -41,12 +41,12 @@ class Config implements ConfigInterface
     /**
      * The value that identifies a version order by creation time.
      */
-    const VERSION_ORDER_CREATION_TIME = 'creation-time';
+    const VERSION_ORDER_CREATION_TIME = 'creation';
 
     /**
-     * The value that identifies a version order by start time.
+     * The value that identifies a version order by execution time.
      */
-    const VERSION_ORDER_START_TIME = 'start-time';
+    const VERSION_ORDER_EXECUTION_TIME = 'execution';
 
     /**
      * @var array
@@ -335,7 +335,7 @@ class Config implements ConfigInterface
             return;
         }
 
-        $validVersionOrders = array(self::VERSION_ORDER_CREATION_TIME, self::VERSION_ORDER_START_TIME);
+        $validVersionOrders = array(self::VERSION_ORDER_CREATION_TIME, self::VERSION_ORDER_EXECUTION_TIME);
 
         if (!in_array($versionOrder, $validVersionOrders)) {
             throw new \RuntimeException(sprintf(

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -39,6 +39,16 @@ use Symfony\Component\Yaml\Yaml;
 class Config implements ConfigInterface
 {
     /**
+     * The value that identifies a version order by creation time.
+     */
+    const VERSION_ORDER_CREATION_TIME = 'creation-time';
+
+    /**
+     * The value that identifies a version order by start time.
+     */
+    const VERSION_ORDER_START_TIME = 'start-time';
+
+    /**
      * @var array
      */
     private $values = array();
@@ -55,6 +65,8 @@ class Config implements ConfigInterface
     {
         $this->configFilePath = $configFilePath;
         $this->values = $this->replaceTokens($configArray);
+
+        $this->setVersionOrder();
     }
 
     /**
@@ -296,6 +308,58 @@ class Config implements ConfigInterface
 
         return $this->values['templates']['class'];
      }
+
+    /**
+     * Get the version order.
+     *
+     * @return string
+     */
+    public function getVersionOrder()
+    {
+        return $this->values['version_order'];
+    }
+
+    /**
+     * Set the version order.
+     * @param string $versionOrder The Version Order to set.
+     */
+    public function setVersionOrder($versionOrder = null)
+    {
+        if (!isset($versionOrder)) {
+            $versionOrder = isset ( $this->values['version_order'] ) ? $this->values['version_order'] : null;
+        }
+
+        if (!isset($versionOrder)) {
+            // if the configuration value is missing we use the default version order (creation time)
+            $this->values['version_order'] = self::VERSION_ORDER_CREATION_TIME;
+            return;
+        }
+
+        $validVersionOrders = array(self::VERSION_ORDER_CREATION_TIME, self::VERSION_ORDER_START_TIME);
+
+        if (!in_array($versionOrder, $validVersionOrders)) {
+            throw new \RuntimeException(sprintf(
+                'Invalid version_order configuration option: %s. Valid values: %s',
+                $versionOrder, implode (' or ', $validVersionOrders)
+            ));
+        }
+
+        $this->values['version_order'] = $versionOrder;
+    }
+    
+    /**
+     * Is version order creation time?
+     *
+     * @return boolean
+     */
+    public function isVersionOrderCreationTime()
+    {
+        $versionOrder = $this->getVersionOrder();
+
+        return $versionOrder == self::VERSION_ORDER_CREATION_TIME;
+    }
+
+    
 
     /**
      * Replace tokens in the specified array.

--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -65,8 +65,6 @@ class Config implements ConfigInterface
     {
         $this->configFilePath = $configFilePath;
         $this->values = $this->replaceTokens($configArray);
-
-        $this->setVersionOrder();
     }
 
     /**
@@ -316,37 +314,13 @@ class Config implements ConfigInterface
      */
     public function getVersionOrder()
     {
+        if (!isset($this->values['version_order'])) {
+            return self::VERSION_ORDER_CREATION_TIME;
+        }
+
         return $this->values['version_order'];
     }
 
-    /**
-     * Set the version order.
-     * @param string $versionOrder The Version Order to set.
-     */
-    public function setVersionOrder($versionOrder = null)
-    {
-        if (!isset($versionOrder)) {
-            $versionOrder = isset ( $this->values['version_order'] ) ? $this->values['version_order'] : null;
-        }
-
-        if (!isset($versionOrder)) {
-            // if the configuration value is missing we use the default version order (creation time)
-            $this->values['version_order'] = self::VERSION_ORDER_CREATION_TIME;
-            return;
-        }
-
-        $validVersionOrders = array(self::VERSION_ORDER_CREATION_TIME, self::VERSION_ORDER_EXECUTION_TIME);
-
-        if (!in_array($versionOrder, $validVersionOrders)) {
-            throw new \RuntimeException(sprintf(
-                'Invalid version_order configuration option: %s. Valid values: %s',
-                $versionOrder, implode (' or ', $validVersionOrders)
-            ));
-        }
-
-        $this->values['version_order'] = $versionOrder;
-    }
-    
     /**
      * Is version order creation time?
      *

--- a/src/Phinx/Config/ConfigInterface.php
+++ b/src/Phinx/Config/ConfigInterface.php
@@ -117,6 +117,20 @@ interface ConfigInterface extends \ArrayAccess
     public function getTemplateClass();
 
     /**
+     * Get the version order.
+     *
+     * @return string
+     */
+    public function getVersionOrder();
+
+    /**
+     * Is version order creation time?
+     *
+     * @return boolean
+     */
+    public function isVersionOrderCreationTime();
+
+    /**
      * Gets the base class name for migrations.
      *
      * @param boolean $dropNamespace Return the base migration class name without the namespace.

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -150,13 +150,11 @@ EOT
             4 => '0101000000',
         );
 
-        if (isset($dateStrlenToAppend[strlen($date)])) {
-            $target = $date . $dateStrlenToAppend[strlen($date)];
-        }
-
-        if ($target === null) {
+        if (!isset($dateStrlenToAppend[strlen($date)])) {
             throw new \InvalidArgumentException('Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].');
         }
+
+        $target = $date . $dateStrlenToAppend[strlen($date)];
 
         $dateTime = \DateTime::createFromFormat('YmdHis', $target);
 

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -109,7 +109,7 @@ EOT
         }
         
         $versionOrder = $this->getConfig()->getVersionOrder();
-        $output->writeln('<info>ordering by </info>' . $versionOrder);
+        $output->writeln('<info>ordering by </info>' . $versionOrder . " time");
 
         // rollback the specified environment
         if (null === $date) {

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -132,7 +132,7 @@ EOT
      * Get Target from Date
      *
      * @param string $date The date to convert to a target.
-     * @return The target
+     * @return string The target
      */
     public function getTargetFromDate($date)
     {

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -137,8 +137,7 @@ EOT
     public function getTargetFromDate($date)
     {
         if (!preg_match('/^\d{4,14}$/', $date)) {
-            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
-                'part, but the missing part(s) must all be in the end of the date string)');
+            throw new \InvalidArgumentException('Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].');
         }
 
         // what we need to append to the date according to the possible date string lengths
@@ -156,15 +155,13 @@ EOT
         }
 
         if ($target === null) {
-            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
-                'part, but the missing part(s) must all be in the end of the date string)');
+            throw new \InvalidArgumentException('Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].');
         }
 
         $dateTime = \DateTime::createFromFormat('YmdHis', $target);
 
         if ($dateTime === false) {
-            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
-                'part, but the missing part(s) must all be in the end of the date string)');
+            throw new \InvalidArgumentException('Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].');
         }
 
         return $dateTime->format('YmdHis');

--- a/src/Phinx/Console/Command/Rollback.php
+++ b/src/Phinx/Console/Command/Rollback.php
@@ -31,6 +31,7 @@ namespace Phinx\Console\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Phinx\Config\Config;
 
 class Rollback extends AbstractCommand
 {
@@ -61,6 +62,10 @@ The <info>rollback</info> command reverts the last migration, or optionally up t
 If you have a breakpoint set, then you can rollback to target 0 and the rollbacks will stop at the breakpoint.
 <info>phinx rollback -e development -t 0 </info>
 
+The <info>version_order</info> configuration option is used to determine the order of the migrations when rolling back.
+This can be used to allow the rolling back of the last executed migration instead of the last created one, or combined 
+with the <info>-d|--date</info> option to rollback to a certain date using the migration start times to order them.
+
 EOT
              );
     }
@@ -81,14 +86,16 @@ EOT
         $date        = $input->getOption('date');
         $force       = !!$input->getOption('force');
 
+        $config = $this->getConfig();
+
         if (null === $environment) {
-            $environment = $this->getConfig()->getDefaultEnvironment();
+            $environment = $config->getDefaultEnvironment();
             $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
         } else {
             $output->writeln('<info>using environment</info> ' . $environment);
         }
 
-        $envOptions = $this->getConfig()->getEnvironment($environment);
+        $envOptions = $config->getEnvironment($environment);
         if (isset($envOptions['adapter'])) {
             $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
         }
@@ -100,17 +107,66 @@ EOT
         if (isset($envOptions['name'])) {
             $output->writeln('<info>using database</info> ' . $envOptions['name']);
         }
+        
+        $versionOrder = $this->getConfig()->getVersionOrder();
+        $output->writeln('<info>ordering by </info>' . $versionOrder);
 
         // rollback the specified environment
-        $start = microtime(true);
-        if (null !== $date) {
-            $this->getManager()->rollbackToDateTime($environment, new \DateTime($date), $force);
+        if (null === $date) {
+            $targetMustMatchVersion = true;
+            $target = $version;
         } else {
-            $this->getManager()->rollback($environment, $version, $force);
+            $targetMustMatchVersion = false;
+            $target = $this->getTargetFromDate($date);
         }
+
+        $start = microtime(true);
+        $this->getManager()->rollback($environment, $target, $force, $targetMustMatchVersion);
         $end = microtime(true);
 
         $output->writeln('');
         $output->writeln('<comment>All Done. Took ' . sprintf('%.4fs', $end - $start) . '</comment>');
+    }
+
+    /**
+     * Get Target from Date
+     *
+     * @param string $date The date to convert to a target.
+     * @return The target
+     */
+    public function getTargetFromDate($date)
+    {
+        if (!preg_match('/^\d{4,14}$/', $date)) {
+            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
+                'part, but the missing part(s) must all be in the end of the date string)');
+        }
+
+        // what we need to append to the date according to the possible date string lengths
+        $dateStrlenToAppend = array(
+            14 => '',
+            12 => '00',
+            10 => '0000',
+            8 => '000000',
+            6 => '01000000',
+            4 => '0101000000',
+        );
+
+        if (isset($dateStrlenToAppend[strlen($date)])) {
+            $target = $date . $dateStrlenToAppend[strlen($date)];
+        }
+
+        if ($target === null) {
+            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
+                'part, but the missing part(s) must all be in the end of the date string)');
+        }
+
+        $dateTime = \DateTime::createFromFormat('YmdHis', $target);
+
+        if ($dateTime === false) {
+            throw new \InvalidArgumentException('Invalid date. Format is YYYYmmddHHiiss (with no mandatory '.
+                'part, but the missing part(s) must all be in the end of the date string)');
+        }
+
+        return $dateTime->format('YmdHis');
     }
 }

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -82,7 +82,7 @@ EOT
             $output->writeln('<info>using format</info> ' . $format);
         }
 
-        $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder());
+        $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder() . " time");
 
         // print the status
         return $this->getManager()->printStatus($environment, $format);

--- a/src/Phinx/Console/Command/Status.php
+++ b/src/Phinx/Console/Command/Status.php
@@ -52,6 +52,8 @@ The <info>status</info> command prints a list of all migrations, along with thei
 
 <info>phinx status -e development</info>
 <info>phinx status -e development -f json</info>
+
+The <info>version_order</info> configuration option is used to determine the order of the status migrations.
 EOT
              );
     }
@@ -79,6 +81,8 @@ EOT
         if (null !== $format) {
             $output->writeln('<info>using format</info> ' . $format);
         }
+
+        $output->writeln('<info>ordering by </info>' . $this->getConfig()->getVersionOrder());
 
         // print the status
         return $this->getManager()->printStatus($environment, $format);

--- a/src/Phinx/Db/Adapter/AdapterInterface.php
+++ b/src/Phinx/Db/Adapter/AdapterInterface.php
@@ -81,8 +81,9 @@ interface AdapterInterface
     public function getVersions();
 
     /**
-     * Get all migration log entries, indexed by version number.
-     *
+     * Get all migration log entries, indexed by version creation time and sorted ascendingly by the configuration's 
+     * version order option
+     * 
      * @return array
      */
     public function getVersionLog();

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -408,8 +408,18 @@ abstract class PdoAdapter implements AdapterInterface
     public function getVersionLog()
     {
         $result = array();
-        $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY version ASC', $this->getSchemaTableName()));
-        foreach ($rows as $version) {
+
+        switch ($this->options['version_order']) {
+            case \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME:
+                $orderBy = 'version ASC';
+                break;
+            case \Phinx\Config\Config::VERSION_ORDER_START_TIME:
+                $orderBy = 'start_time ASC, version ASC';
+                break;
+        }
+
+        $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY %s', $this->getSchemaTableName(), $orderBy));
+        foreach($rows as $version) {
             $result[$version['version']] = $version;
         }
 

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -413,7 +413,7 @@ abstract class PdoAdapter implements AdapterInterface
             case \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME:
                 $orderBy = 'version ASC';
                 break;
-            case \Phinx\Config\Config::VERSION_ORDER_START_TIME:
+            case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
                 $orderBy = 'start_time ASC, version ASC';
                 break;
         }

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -416,6 +416,8 @@ abstract class PdoAdapter implements AdapterInterface
             case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
                 $orderBy = 'start_time ASC, version ASC';
                 break;
+            default:
+                throw new \RuntimeException('Invalid version_order configuration option');
         }
 
         $rows = $this->fetchAll(sprintf('SELECT * FROM %s ORDER BY %s', $this->getSchemaTableName(), $orderBy));

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -115,7 +115,7 @@ class Manager
                 case \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME:
                     $migrationIdAndStartedHeader = "<info>[Migration ID]</info>  Started            ";
                     break;
-                case \Phinx\Config\Config::VERSION_ORDER_START_TIME:
+                case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
                     $migrationIdAndStartedHeader = "Migration ID    <info>[Started          ]</info>";
                     break;
             }
@@ -426,7 +426,7 @@ class Manager
         $sortedMigrations = array();
 
         foreach ($executedVersions as $versionCreationTime => &$executedVersion) {
-            // if we have a date (ie. the target must not match a version) and we are sorting by start time, we
+            // if we have a date (ie. the target must not match a version) and we are sorting by execution time, we
             // convert the version start time so we can compare directly with the target date
             if (!$this->getConfig()->isVersionOrderCreationTime() && !$targetMustMatchVersion) {
                 $dateTime = \DateTime::createFromFormat('Y-m-d H:i:s', $executedVersion['start_time']);

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -118,6 +118,8 @@ class Manager
                 case \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME:
                     $migrationIdAndStartedHeader = "Migration ID    <info>[Started          ]</info>";
                     break;
+                default:
+                    throw new \RuntimeException('Invalid version_order configuration option');
             }
 
             $output->writeln(" Status  $migrationIdAndStartedHeader  Finished             Migration Name ");

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -211,42 +211,6 @@ class Manager
     }
 
     /**
-     * Roll back to the version of the database on a given date.
-     *
-     * @param string    $environment Environment
-     * @param \DateTime $dateTime    Date to roll back to
-     * @param bool $force
-     *
-     * @return void
-     */
-    public function rollbackToDateTime($environment, \DateTime $dateTime, $force = false)
-    {
-        $env        = $this->getEnvironment($environment);
-        $versions   = $env->getVersions();
-        $dateString = $dateTime->format('YmdHis');
-        sort($versions);
-
-        $earlierVersion = null;
-        $availableMigrations = array_filter($versions, function($version) use($dateString, &$earlierVersion) {
-            if ($version <= $dateString) {
-                $earlierVersion = $version;
-            }
-            return $version >= $dateString;
-        });
-
-        if (count($availableMigrations) > 0) {
-            if (is_null($earlierVersion)) {
-                $this->getOutput()->writeln('Rolling back all migrations');
-                $migration = 0;
-            } else {
-                $this->getOutput()->writeln('Rolling back to version ' . $earlierVersion);
-                $migration = $earlierVersion;
-            }
-            $this->rollback($environment, $migration, $force);
-        }
-    }
-
-    /**
      * Migrate an environment to the specified version.
      *
      * @param string $environment Environment
@@ -368,60 +332,92 @@ class Manager
      * Rollback an environment to the specified version.
      *
      * @param string $environment Environment
-     * @param int $version
+     * @param int $target
      * @param bool $force
+     * @param bool $targetMustMatchVersion
      * @return void
      */
-    public function rollback($environment, $version = null, $force = false)
+    public function rollback($environment, $target = null, $force = false, $targetMustMatchVersion = true)
     {
+        // note that the migrations are indexed by name (aka creation time) in ascending order
         $migrations = $this->getMigrations();
-        $versionLog = $this->getEnvironment($environment)->getVersionLog();
-        $versions = array_keys($versionLog);
 
-        ksort($migrations);
-        sort($versions);
+        // note that the version log are also indexed by name with the proper ascending order according to the version order
+        $executedVersions = $this->getEnvironment($environment)->getVersionLog();
+
+        if ($target === "0") {
+            $target = 0;
+        }
+
+        // get a list of migrations sorted in the opposite way of the executed versions
+        $sortedMigrations = array();
+
+        foreach ($executedVersions as $versionCreationTime => &$executedVersion) {
+            // if we have a date (ie. the target must not match a version) and we are sorting by start time, we
+            // convert the version start time so we can compare directly with the target date
+            if (!$this->getConfig()->isVersionOrderCreationTime() && !$targetMustMatchVersion) {
+                $dateTime = \DateTime::createFromFormat('Y-m-d H:i:s', $executedVersion['start_time']);
+                $executedVersion['start_time'] = $dateTime->format('YmdHis');
+            }
+
+            if (isset($migrations[$versionCreationTime])) {
+                array_unshift($sortedMigrations, $migrations[$versionCreationTime]);
+            } else {
+                // this means the version is missing so we unset it so that we don't consider it when rolling back 
+                // migrations (or choosing the last up version as target)
+                unset($executedVersions[$versionCreationTime]);
+            }
+        }
 
         // Check we have at least 1 migration to revert
-        if (empty($versions) || $version == end($versions)) {
+        $executedVersionCreationTimes = array_keys($executedVersions);
+        if (empty($executedVersionCreationTimes) || $target == end($executedVersionCreationTimes)) {
             $this->getOutput()->writeln('<error>No migrations to rollback</error>');
             return;
         }
 
-        // If no target version was supplied, revert the last migration
-        if (null === $version) {
+        // If no target was supplied, revert the last migration
+        if (null === $target) {
             // Get the migration before the last run migration
-            $prev = count($versions) - 2;
-            $version =  $prev < 0 ? 0 : $versions[$prev];
-        } else {
-            // Get the first migration number
-            $first = $versions[0];
-
-            // If the target version is before the first migration, revert all migrations
-            if ($version < $first) {
-                $version = 0;
-            }
+            $prev = count($executedVersionCreationTimes) - 2;
+            $target = $prev >= 0 ? $executedVersionCreationTimes[$prev] : $executedVersionCreationTimes[0];
         }
 
-        // Check the target version exists
-        if (0 !== $version && !isset($migrations[$version])) {
-            $this->getOutput()->writeln("<error>Target version ($version) not found</error>");
+        // If the target must match a version, check the target version exists
+        if ($targetMustMatchVersion && 0 !== $target && !isset($migrations[$target])) {
+            $this->getOutput()->writeln("<error>Target version ($target) not found</error>");
             return;
         }
 
-        // Revert the migration(s)
-        krsort($migrations);
-        foreach ($migrations as $migration) {
-            if ($migration->getVersion() <= $version) {
+        // Rollback all versions until we find the wanted rollback target
+        $rollbacked = false;
+
+        foreach ($sortedMigrations as $migration) {
+            if ($targetMustMatchVersion && $migration->getVersion() == $target) {
                 break;
             }
 
-            if (in_array($migration->getVersion(), $versions)) {
-                if (isset($versionLog[$migration->getVersion()]) && 0 != $versionLog[$migration->getVersion()]['breakpoint'] && !$force){
+            if (in_array($migration->getVersion(), $executedVersionCreationTimes)) {
+                $executedVersion = $executedVersions[$migration->getVersion()];
+
+                if (!$targetMustMatchVersion) {
+                    if (($this->getConfig()->isVersionOrderCreationTime() && $executedVersion['version'] <= $target) ||
+                        (!$this->getConfig()->isVersionOrderCreationTime() && $executedVersion['start_time'] <= $target)) {
+                        break;
+                    }
+                }
+
+                if (0 != $executedVersion['breakpoint'] && !$force){
                     $this->getOutput()->writeln('<error>Breakpoint reached. Further rollbacks inhibited.</error>');
                     break;
                 }
                 $this->executeMigration($environment, $migration, MigrationInterface::DOWN);
+                $rollbacked = true;
             }
+        }
+
+        if (!$rollbacked) {
+            $this->getOutput()->writeln('<error>No migrations to rollback</error>');
         }
     }
 
@@ -487,7 +483,10 @@ class Manager
         }
 
         // create an environment instance and cache it
-        $environment = new Environment($name, $this->getConfig()->getEnvironment($name));
+        $envOptions = $this->getConfig()->getEnvironment($name);
+        $envOptions['version_order'] = $this->getConfig()->getVersionOrder();
+
+        $environment = new Environment($name, $envOptions);
         $this->environments[$name] = $environment;
         $environment->setInput($this->getInput());
         $environment->setOutput($this->getOutput());
@@ -552,7 +551,8 @@ class Manager
     }
 
     /**
-     * Gets an array of the database migrations.
+     * Gets an array of the database migrations, indexed by migration name (aka creation time) and sorted in ascending 
+     * order
      *
      * @throws \InvalidArgumentException
      * @return AbstractMigration[]

--- a/src/Phinx/Migration/Manager/Environment.php
+++ b/src/Phinx/Migration/Manager/Environment.php
@@ -259,7 +259,8 @@ class Environment
     }
 
     /**
-     * Get all migration log entries, indexed by version number.
+     * Get all migration log entries, indexed by version creation time and sorted ascendingly by the configuration's 
+     * version_order option
      *
      * @return array
      */

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -244,8 +244,8 @@ class ConfigTest extends AbstractConfigTest
     public function testGetVersionOrder()
     {
         $config = new \Phinx\Config\Config(array());
-        $config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
-        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_START_TIME, $config->getVersionOrder());
+        $config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, $config->getVersionOrder());
     }
 
     /**
@@ -254,8 +254,8 @@ class ConfigTest extends AbstractConfigTest
     public function testSetVersionOrder()
     {
         $config = new \Phinx\Config\Config(array());
-        $config->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_START_TIME);
-        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_START_TIME, $config['version_order']);
+        $config->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
+        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, $config['version_order']);
     }
 
     /**
@@ -271,7 +271,7 @@ class ConfigTest extends AbstractConfigTest
     /**
      * @covers \Phinx\Config\Config::setVersionOrder
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Invalid version_order configuration option: bad-order. Valid values: creation-time or start-time
+     * @expectedExceptionMessage Invalid version_order configuration option: bad-order. Valid values: creation or execution
      */
     public function testSetVersionOrderThrowsException()
     {
@@ -305,9 +305,9 @@ class ConfigTest extends AbstractConfigTest
             [
                 \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, true
             ],
-            'With Start Time Version Order' =>
+            'With Execution Time Version Order' =>
             [
-                \Phinx\Config\Config::VERSION_ORDER_START_TIME, false
+                \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, false
             ],
         ];
     }

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -249,37 +249,6 @@ class ConfigTest extends AbstractConfigTest
     }
 
     /**
-     * @covers \Phinx\Config\Config::setVersionOrder
-     */
-    public function testSetVersionOrder()
-    {
-        $config = new \Phinx\Config\Config(array());
-        $config->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
-        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, $config['version_order']);
-    }
-
-    /**
-     * @covers \Phinx\Config\Config::setVersionOrder
-     */
-    public function testSetVersionOrderDefault()
-    {
-        $config = new \Phinx\Config\Config(array());
-        $config->setVersionOrder();
-        $this->assertEquals(\Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, $config['version_order']);
-    }
-    
-    /**
-     * @covers \Phinx\Config\Config::setVersionOrder
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Invalid version_order configuration option: bad-order. Valid values: creation or execution
-     */
-    public function testSetVersionOrderThrowsException()
-    {
-        $config = new \Phinx\Config\Config(array());
-        $config->setVersionOrder('bad-order');
-    }
-
-    /**
      * @covers \Phinx\Config\Config::isVersionOrderCreationTime
      * @dataProvider isVersionOrderCreationTimeDataProvider
      */

--- a/tests/Phinx/Config/ConfigTest.php
+++ b/tests/Phinx/Config/ConfigTest.php
@@ -255,7 +255,10 @@ class ConfigTest extends AbstractConfigTest
     public function testIsVersionOrderCreationTime($versionOrder, $expected)
     {
         // get config stub
-        $configStub = $this->getMock('\Phinx\Config\Config', array('getVersionOrder'), array(array()));
+        $configStub = $this->getMockBuilder('\Phinx\Config\Config')
+            ->setMethods(array('getVersionOrder'))
+            ->setConstructorArgs(array(array()))
+            ->getMock();
 
         $configStub->expects($this->once())
             ->method('getVersionOrder')

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -31,6 +31,11 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
      */
     protected $output;
 
+    /**
+     * Default Test Environment
+     */
+    const DEFAULT_TEST_ENVIRONMENT = 'development';
+
     protected function setUp()
     {
         $this->config = new Config(array(
@@ -69,7 +74,8 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->once())
-                    ->method('rollback');
+                    ->method('rollback')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, null, false, true);
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -77,7 +83,12 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
 
-        $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
+        $display = $commandTester->getDisplay();
+
+        $this->assertRegExp('/no environment specified/', $display);
+
+        // note that the default order is by creation-time
+        $this->assertRegExp('/ordering by creation-time/', $display);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -94,7 +105,8 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->once())
-                    ->method('rollback');
+                    ->method('rollback')
+                    ->with('fakeenv', null, false, true);
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -118,7 +130,8 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs([$this->config, $this->input, $this->output])
             ->getMock();
         $managerStub->expects($this->once())
-                    ->method('rollback');
+                    ->method('rollback')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, null, false);
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -126,5 +139,138 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
         $this->assertRegExp('/using database development/', $commandTester->getDisplay());
+    }
+    
+    public function testStartTimeVersionOrder()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Rollback());
+
+        // setup dependencies
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub->expects($this->once())
+                    ->method('rollback')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, null, false, true);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
+        $this->assertRegExp('/ordering by start-time/', $commandTester->getDisplay());
+    }
+    
+    public function testWithDate()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+
+        $date = '20160101';
+        $target = '20160101000000';
+        $rollbackStub = $this->getMock('\Phinx\Console\Command\Rollback', array('getTargetFromDate'));
+        $rollbackStub->expects($this->once())
+                    ->method('getTargetFromDate')
+                    ->with($date)
+                    ->will($this->returnValue($target));
+
+        $application->add($rollbackStub);
+
+        // setup dependencies
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub->expects($this->once())
+                    ->method('rollback')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, $target, false, false);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '-d' => $date), array('decorated' => false));
+    }
+
+    /**
+     * @dataProvider getTargetFromDataProvider
+     */
+    public function testGetTargetFromDate($date, $expectedTarget)
+    {
+        $rollbackCommand = new Rollback();
+        $this->assertEquals($expectedTarget, $rollbackCommand->getTargetFromDate($date));
+    }
+
+    public function getTargetFromDataProvider()
+    {
+        return [
+            'Date with only year' => [
+                '2015', '20150101000000'
+            ],
+            'Date with year and month' => [
+                '201409', '20140901000000'
+            ],
+            'Date with year, month and day' => [
+                '20130517', '20130517000000'
+            ],
+            'Date with year, month, day and hour' => [
+                '2013051406', '20130514060000'
+            ],
+            'Date with year, month, day, hour and minutes' => [
+                '201305140647', '20130514064700'
+            ],
+            'Date with year, month, day, hour, minutes and seconds' => [
+                '20130514064726', '20130514064726'
+            ]
+        ];
+    }
+
+
+    /**
+     * @dataProvider getTargetFromDateThrowsExceptionDataProvider
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid date. Format is YYYYmmddHHiiss (with no mandatory part, but the missing part(s) must all be in the end of the date string)
+     */
+    public function testGetTargetFromDateThrowsException($invalidDate)
+    {
+        $rollbackCommand = new Rollback();
+        $rollbackCommand->getTargetFromDate($invalidDate);
+    }
+    
+    public function getTargetFromDateThrowsExceptionDataProvider()
+    {
+        return [
+            ['20'],
+            ['2015060522354698'],
+            ['invalid']
+        ];
+    }
+
+    public function testStarTimeVersionOrderWithDate()
+    {
+        $application = new \Phinx\Console\PhinxApplication('testing');
+        $application->add(new Rollback());
+
+        // setup dependencies
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+
+        $command = $application->find('rollback');
+
+        // mock the manager class
+        $targetDate = '20150101';
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub->expects($this->once())
+                    ->method('rollback')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, '20150101000000', false, false);
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName(), '-d' => $targetDate), array('decorated' => false));
+        $this->assertRegExp('/ordering by start-time/', $commandTester->getDisplay());
     }
 }

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -232,7 +232,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getTargetFromDateThrowsExceptionDataProvider
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid date. Format is YYYYmmddHHiiss (with no mandatory part, but the missing part(s) must all be in the end of the date string)
+     * @expectedExceptionMessage Invalid date. Format is YYYY[MM[DD[HH[II[SS]]]]].
      */
     public function testGetTargetFromDateThrowsException($invalidDate)
     {

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -87,8 +87,8 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         $this->assertRegExp('/no environment specified/', $display);
 
-        // note that the default order is by creation-time
-        $this->assertRegExp('/ordering by creation-time/', $display);
+        // note that the default order is by creation time
+        $this->assertRegExp('/ordering by creation time/', $display);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -147,7 +147,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $application->add(new Rollback());
 
         // setup dependencies
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command = $application->find('rollback');
 
@@ -162,7 +162,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
-        $this->assertRegExp('/ordering by start-time/', $commandTester->getDisplay());
+        $this->assertRegExp('/ordering by execution time/', $commandTester->getDisplay());
     }
     
     public function testWithDate()
@@ -255,7 +255,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $application->add(new Rollback());
 
         // setup dependencies
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command = $application->find('rollback');
 
@@ -271,6 +271,6 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '-d' => $targetDate), array('decorated' => false));
-        $this->assertRegExp('/ordering by start-time/', $commandTester->getDisplay());
+        $this->assertRegExp('/ordering by execution time/', $commandTester->getDisplay());
     }
 }

--- a/tests/Phinx/Console/Command/RollbackTest.php
+++ b/tests/Phinx/Console/Command/RollbackTest.php
@@ -152,7 +152,10 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('rollback');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs(array($this->config, $this->input, $this->output))
+            ->getMock();
+
         $managerStub->expects($this->once())
                     ->method('rollback')
                     ->with(self::DEFAULT_TEST_ENVIRONMENT, null, false, true);
@@ -171,7 +174,10 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         $date = '20160101';
         $target = '20160101000000';
-        $rollbackStub = $this->getMock('\Phinx\Console\Command\Rollback', array('getTargetFromDate'));
+        $rollbackStub = $this->getMockBuilder('\Phinx\Console\Command\Rollback')
+            ->setMethods(array('getTargetFromDate'))
+            ->getMock();
+
         $rollbackStub->expects($this->once())
                     ->method('getTargetFromDate')
                     ->with($date)
@@ -183,7 +189,9 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $command = $application->find('rollback');
 
         // mock the manager class
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs(array($this->config, $this->input, $this->output))
+            ->getMock();
         $managerStub->expects($this->once())
                     ->method('rollback')
                     ->with(self::DEFAULT_TEST_ENVIRONMENT, $target, false, false);
@@ -261,7 +269,9 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         $targetDate = '20150101';
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs(array($this->config, $this->input, $this->output))
+            ->getMock();
         $managerStub->expects($this->once())
                     ->method('rollback')
                     ->with(self::DEFAULT_TEST_ENVIRONMENT, '20150101000000', false, false);

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -89,8 +89,8 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $display = $commandTester->getDisplay();
         $this->assertRegExp('/no environment specified/', $display);
         
-        // note that the default order is by creation-time
-        $this->assertRegExp('/ordering by creation-time/', $display);
+        // note that the default order is by creation time
+        $this->assertRegExp('/ordering by creation time/', $display);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -147,7 +147,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/using format json/', $commandTester->getDisplay());
     }
 
-    public function testExecuteVersionOrderByStartTime()
+    public function testExecuteVersionOrderByExecutionTime()
     {
         $application = new PhinxApplication('testing');
         $application->add(new Status());
@@ -163,7 +163,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
                     ->with(self::DEFAULT_TEST_ENVIRONMENT, null)
                     ->will($this->returnValue(0));
 
-        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
 
         $command->setConfig($this->config);
         $command->setManager($managerStub);
@@ -175,6 +175,6 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
         $display = $commandTester->getDisplay();
         $this->assertRegExp('/no environment specified/', $display);
-        $this->assertRegExp('/ordering by start-time/', $display);
+        $this->assertRegExp('/ordering by execution time/', $display);
     }
 }

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -31,6 +31,11 @@ class StatusTest extends \PHPUnit_Framework_TestCase
      */
     protected $output;
 
+    /**
+     * Default Test Environment
+     */
+    const DEFAULT_TEST_ENVIRONMENT = 'development';
+
     protected function setUp()
     {
         $this->config = new Config(array(
@@ -70,6 +75,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $managerStub->expects($this->once())
                     ->method('printStatus')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, null)
                     ->will($this->returnValue(0));
 
         $command->setConfig($this->config);
@@ -97,6 +103,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $managerStub->expects($this->once())
                     ->method('printStatus')
+                    ->with('fakeenv', null)
                     ->will($this->returnValue(0));
 
         $command->setConfig($this->config);
@@ -123,6 +130,7 @@ class StatusTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $managerStub->expects($this->once())
                     ->method('printStatus')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, 'json')
                     ->will($this->returnValue(0));
 
         $command->setConfig($this->config);

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -85,7 +85,12 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $return = $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
 
         $this->assertEquals(0, $return);
-        $this->assertRegExp('/no environment specified/', $commandTester->getDisplay());
+
+        $display = $commandTester->getDisplay();
+        $this->assertRegExp('/no environment specified/', $display);
+        
+        // note that the default order is by creation-time
+        $this->assertRegExp('/ordering by creation-time/', $display);
     }
 
     public function testExecuteWithEnvironmentOption()
@@ -140,5 +145,36 @@ class StatusTest extends \PHPUnit_Framework_TestCase
         $return = $commandTester->execute(array('command' => $command->getName(), '--format' => 'json'), array('decorated' => false));
         $this->assertEquals(0, $return);
         $this->assertRegExp('/using format json/', $commandTester->getDisplay());
+    }
+
+    public function testExecuteVersionOrderByStartTime()
+    {
+        $application = new PhinxApplication('testing');
+        $application->add(new Status());
+
+        /** @var Status $command */
+        $command = $application->find('status');
+
+        // mock the manager class
+        /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
+        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub->expects($this->once())
+                    ->method('printStatus')
+                    ->with(self::DEFAULT_TEST_ENVIRONMENT, null)
+                    ->will($this->returnValue(0));
+
+        $this->config['version_order'] = \Phinx\Config\Config::VERSION_ORDER_START_TIME;
+
+        $command->setConfig($this->config);
+        $command->setManager($managerStub);
+
+        $commandTester = new CommandTester($command);
+        $return = $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
+
+        $this->assertEquals(0, $return);
+
+        $display = $commandTester->getDisplay();
+        $this->assertRegExp('/no environment specified/', $display);
+        $this->assertRegExp('/ordering by start-time/', $display);
     }
 }

--- a/tests/Phinx/Console/Command/StatusTest.php
+++ b/tests/Phinx/Console/Command/StatusTest.php
@@ -157,7 +157,9 @@ class StatusTest extends \PHPUnit_Framework_TestCase
 
         // mock the manager class
         /** @var Manager|PHPUnit_Framework_MockObject_MockObject $managerStub */
-        $managerStub = $this->getMock('\Phinx\Migration\Manager', array(), array($this->config, $this->input, $this->output));
+        $managerStub = $this->getMockBuilder('\Phinx\Migration\Manager')
+            ->setConstructorArgs(array($this->config, $this->input, $this->output))
+            ->getMock();
         $managerStub->expects($this->once())
                     ->method('printStatus')
                     ->with(self::DEFAULT_TEST_ENVIRONMENT, null)

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -87,4 +87,16 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
+    
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Invalid version_order configuration option
+     */
+    public function testGetVersionLogInvalidVersionOrderKO()
+    {
+        $adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter', 
+            array(array('version_order' => 'invalid')));
+
+        $adapter->getVersionLog();
+    }
 }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -30,4 +30,61 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
         $this->adapter->setSchemaTableName('schema_table_test');
         $this->assertEquals('schema_table_test', $this->adapter->getSchemaTableName());
     }
+    
+    /**
+     * @dataProvider getVersionLogDataProvider
+     */
+    public function testGetVersionLog($versionOrder, $expectedOrderBy)
+    {
+        $adapter = $this->getMockForAbstractClass('\Phinx\Db\Adapter\PdoAdapter', 
+            array(array('version_order' => $versionOrder)), '', true, true, true,
+            array('fetchAll', 'getSchemaTableName'));
+
+        $schemaTableName = 'log';
+        $adapter->expects($this->once())
+            ->method('getSchemaTableName')
+            ->will($this->returnValue($schemaTableName));
+
+        $mockRows = array (
+            array(
+                'version' => '20120508120534',
+                'key' => 'value'
+            ),
+            array(
+                'version' => '20130508120534',
+                'key' => 'value'
+            ),
+        );
+
+        $adapter->expects($this->once())
+            ->method('fetchAll')
+            ->with("SELECT * FROM $schemaTableName ORDER BY $expectedOrderBy")
+            ->will($this->returnValue($mockRows));
+
+        // we expect the mock rows but indexed by version creation time
+        $expected = array(
+            '20120508120534' => array(
+                'version' => '20120508120534',
+                'key' => 'value'
+            ),
+            '20130508120534' => array(
+                'version' => '20130508120534',
+                'key' => 'value'
+            ),
+        );
+
+        $this->assertEquals($expected, $adapter->getVersionLog());
+    }
+
+    public function getVersionLogDataProvider()
+    {
+        return array(
+            'With Creation Time Version Order' => array(
+                \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, 'version ASC'
+            ),
+            'With Start Time Version Order' => array(
+                \Phinx\Config\Config::VERSION_ORDER_START_TIME, 'start_time ASC, version ASC'
+            ),
+        );
+    }
 }

--- a/tests/Phinx/Db/Adapter/PdoAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PdoAdapterTest.php
@@ -82,8 +82,8 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
             'With Creation Time Version Order' => array(
                 \Phinx\Config\Config::VERSION_ORDER_CREATION_TIME, 'version ASC'
             ),
-            'With Start Time Version Order' => array(
-                \Phinx\Config\Config::VERSION_ORDER_START_TIME, 'start_time ASC, version ASC'
+            'With Execution Time Version Order' => array(
+                \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME, 'start_time ASC, version ASC'
             ),
         );
     }

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -445,6 +445,25 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Invalid version_order configuration option
+     */
+    public function testPrintStatusInvalidVersionOrderKO()
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+
+        $configArray = $this->getConfigArray();
+        $configArray['version_order'] ='invalid';
+        $config = new Config($configArray);
+
+        $this->manager = new Manager($config, $this->input, $this->output);
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->printStatus('mockenv');
+    }
+
     public function testGetMigrationsWithDuplicateMigrationVersions()
     {
         $this->setExpectedException(

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -216,8 +216,61 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         rewind($this->manager->getOutput()->getStream());
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
-        $this->assertRegExp('/up  20120103083300  2012-01-11 23:53:36  2012-01-11 23:53:37  *\*\* MISSING \*\*/', $outputStr);
-        $this->assertRegExp('/up  20120815145812  2012-01-16 18:35:40  2012-01-16 18:35:41  Example   *\*\* MISSING \*\*/', $outputStr);
+
+        // note that the order is important: missing migrations should appear before down migrations
+        $this->assertRegExp('/\s*up  20120103083300  2012-01-11 23:53:36  2012-01-11 23:53:37  *\*\* MISSING \*\*'.PHP_EOL.
+            '\s*up  20120815145812  2012-01-16 18:35:40  2012-01-16 18:35:41  Example   *\*\* MISSING \*\*'.PHP_EOL. 
+            '\s*down  20120111235330                                            TestMigration'.PHP_EOL.
+            '\s*down  20120116183504                                            TestMigration2/', $outputStr);
+    }
+    
+    public function testPrintStatusMethodWithMissingLastMigration()
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->once())
+                ->method('getVersionLog')
+                ->will($this->returnValue(
+                    array (
+                        '20120111235330' => 
+                            array (
+                                'version' => '20120111235330',
+                                'start_time' => '2012-01-16 18:35:40',
+                                'end_time' => '2012-01-16 18:35:41',
+                                'migration_name' => '',
+                                'breakpoint' => 0
+                            ),
+                        '20120116183504' =>
+                            array (
+                                'version' => '20120116183504',
+                                'start_time' => '2012-01-16 18:35:40',
+                                'end_time' => '2012-01-16 18:35:41',
+                                'migration_name' => '',
+                                'breakpoint' => '0',
+                            ),
+                        '20120120145114' =>
+                            array (
+                                'version' => '20120120145114',
+                                'start_time' => '2012-01-20 14:51:14',
+                                'end_time' => '2012-01-20 14:51:14',
+                                'migration_name' => 'Example',
+                                'breakpoint' => '0',
+                            ),
+                    )
+                ));
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->getOutput()->setDecorated(false);
+        $return = $this->manager->printStatus('mockenv');
+        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+
+        rewind($this->manager->getOutput()->getStream());
+        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
+
+        // note that the order is important: missing migrations should appear before down migrations
+        $this->assertRegExp('/\s*up  20120111235330  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration'.PHP_EOL.
+            '\s*up  20120116183504  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration2'.PHP_EOL.
+            '\s*up  20120120145114  2012-01-20 14:51:14  2012-01-20 14:51:14  Example   *\*\* MISSING \*\*/', $outputStr);
     }
 
     public function testPrintStatusMethodWithMissingMigrationsAndBreakpointSet()
@@ -287,6 +340,109 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
         $this->assertRegExp('/up  20120111235330  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration/', $outputStr);
         $this->assertRegExp('/down  20120116183504                                            TestMigration2/', $outputStr);
+    }
+    
+    public function testPrintStatusMethodWithMissingAndDownMigrations()
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->once())
+                ->method('getVersionLog')
+                ->will($this->returnValue(array(
+                    '20120111235330' => 
+                        array (
+                            'version' => '20120111235330',
+                            'start_time' => '2012-01-16 18:35:40',
+                            'end_time' => '2012-01-16 18:35:41',
+                            'migration_name' => '',
+                            'breakpoint' => 0
+                        ),
+                    '20120103083300' =>
+                        array (
+                            'version' => '20120103083300',
+                            'start_time' => '2012-01-11 23:53:36',
+                            'end_time' => '2012-01-11 23:53:37',
+                            'migration_name' => '',
+                            'breakpoint' => 0,
+                        ),
+                    '20120815145812' =>
+                        array (
+                            'version' => '20120815145812',
+                            'start_time' => '2012-01-16 18:35:40',
+                            'end_time' => '2012-01-16 18:35:41',
+                            'migration_name' => 'Example',
+                            'breakpoint' => 0,
+                        ))));
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $this->manager->getOutput()->setDecorated(false);
+        $return = $this->manager->printStatus('mockenv');
+        $this->assertEquals(Manager::EXIT_STATUS_MISSING, $return);
+
+        rewind($this->manager->getOutput()->getStream());
+        $outputStr = stream_get_contents($this->manager->getOutput()->getStream());
+        
+        // note that the order is important: missing migrations should appear before down migrations (and in the right 
+        // place with regard to other up non-missing migrations)
+        $this->assertRegExp('/\s*up  20120103083300  2012-01-11 23:53:36  2012-01-11 23:53:37  *\*\* MISSING \*\*'.PHP_EOL.
+            '\s*up  20120111235330  2012-01-16 18:35:40  2012-01-16 18:35:41  TestMigration'.PHP_EOL. 
+            '\s*down  20120116183504                                            TestMigration2/', $outputStr);
+    }
+    
+    /**
+     * Test that ensures the status header is correctly printed with regards to the version order
+     *
+     * @dataProvider statusVersionOrderProvider
+     *
+     * @param array  $config
+     * @param string $expectedStatusHeader
+     */
+    public function testPrintStatusMethodVersionOrderHeader($config, $expectedStatusHeader)
+    {
+        // stub environment
+        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub->expects($this->once())
+                ->method('getVersionLog')
+                ->will($this->returnValue(array()));
+
+        $output = new RawBufferedOutput();
+        $this->manager = new Manager($config, $this->input, $output);
+
+        $this->manager->setEnvironments(array('mockenv' => $envStub));
+        $return = $this->manager->printStatus('mockenv');
+        $this->assertEquals(Manager::EXIT_STATUS_DOWN, $return);
+
+        $outputStr = $this->manager->getOutput()->fetch();
+        $this->assertContains($expectedStatusHeader, $outputStr);
+    }
+
+    public function statusVersionOrderProvider()
+    {
+        // create the necessary configuration objects
+        $configArray = $this->getConfigArray();
+
+        $configWithNoVersionOrder = new Config($configArray);
+
+        $configArray['version_order'] = Config::VERSION_ORDER_CREATION_TIME;
+        $configWithCreationTimeVersionOrder = new Config($configArray);
+
+        $configArray['version_order'] = Config::VERSION_ORDER_START_TIME;
+        $configWithStartTimeVersionOrder = new Config($configArray);
+
+        return [
+            'With the default version order' => [
+                $configWithNoVersionOrder,
+                ' Status  <info>[Migration ID]</info>  Started              Finished             Migration Name '
+            ],
+            'With the creation-time version order' => [
+                $configWithCreationTimeVersionOrder,
+                ' Status  <info>[Migration ID]</info>  Started              Finished             Migration Name '
+            ],
+            'With the start-time version order' => [
+                $configWithStartTimeVersionOrder,
+                ' Status  Migration ID    <info>[Started          ]</info>  Finished             Migration Name '
+            ]
+        ];
     }
 
     public function testGetMigrationsWithDuplicateMigrationVersions()
@@ -2041,5 +2197,17 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $output = stream_get_contents($this->manager->getOutput()->getStream());
 
         $this->assertContains('is not a valid version', $output);
+    }
+}
+
+/**
+ * RawBufferedOutput is a specialized BufferedOutput that outputs raw "writeln" calls (ie. it doesn't replace the
+ * tags like <info>message</info>.
+ */
+class RawBufferedOutput extends \Symfony\Component\Console\Output\BufferedOutput
+{
+    public function writeln($messages, $options = self::OUTPUT_RAW)
+    {
+        $this->write($messages, true, $options);
     }
 }

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -227,7 +227,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithMissingLastMigration()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
                 ->will($this->returnValue(
@@ -345,7 +347,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodWithMissingAndDownMigrations()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
                 ->will($this->returnValue(array(
@@ -400,7 +404,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusMethodVersionOrderHeader($config, $expectedStatusHeader)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
         $envStub->expects($this->once())
                 ->method('getVersionLog')
                 ->will($this->returnValue(array()));
@@ -452,7 +458,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPrintStatusInvalidVersionOrderKO()
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
 
         $configArray = $this->getConfigArray();
         $configArray['version_order'] ='invalid';
@@ -591,7 +599,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbackToDate($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
@@ -622,7 +632,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbackToVersionByExecutionTime($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
@@ -663,7 +675,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbackToDateByExecutionTime($availableRollbacks, $date, $expectedOutput)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
@@ -759,7 +773,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testRollbackLast($availableRolbacks, $versionOrder, $expectedOutput)
     {
         // stub environment
-        $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
+        $envStub = $this->getMockBuilder('\Phinx\Migration\Manager\Environment')
+            ->setConstructorArgs(array('mockenv', array()))
+            ->getMock();
         $envStub->expects($this->any())
             ->method('getVersionLog')
             ->will($this->returnValue($availableRolbacks));

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -608,8 +608,15 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
-        // set the manager's config version order to execution time
-        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
+        // get a manager with a config whose version order is set to execution time
+        $configArray = $this->getConfigArray();
+        $configArray['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $config = new Config($configArray);
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
+        $this->output->setDecorated(false);
+        
+        $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv', $version);
         rewind($this->manager->getOutput()->getStream());
@@ -642,8 +649,15 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
-        // set the manager's config version order to execution time
-        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
+        // get a manager with a config whose version order is set to execution time
+        $configArray = $this->getConfigArray();
+        $configArray['version_order'] = \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME;
+        $config = new Config($configArray);
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
+        $this->output->setDecorated(false);
+        
+        $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv', $date, false, false);
         rewind($this->manager->getOutput()->getStream());
@@ -731,7 +745,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRolbacks));
 
-        $this->manager->getConfig()->setVersionOrder($versionOrder);
+        // get a manager with a config whose version order is set to execution time
+        $configArray = $this->getConfigArray();
+        $configArray['version_order'] = $versionOrder;
+        $config = new Config($configArray);
+        $this->input = new ArrayInput([]);
+        $this->output = new StreamOutput(fopen('php://memory', 'a', false));
+        $this->output->setDecorated(false);
+        $this->manager = new Manager($config, $this->input, $this->output);
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv', null);
         rewind($this->manager->getOutput()->getStream());

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -424,22 +424,22 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $configWithNoVersionOrder = new Config($configArray);
 
         $configArray['version_order'] = Config::VERSION_ORDER_CREATION_TIME;
-        $configWithCreationTimeVersionOrder = new Config($configArray);
+        $configWithCreationVersionOrder = new Config($configArray);
 
-        $configArray['version_order'] = Config::VERSION_ORDER_START_TIME;
-        $configWithStartTimeVersionOrder = new Config($configArray);
+        $configArray['version_order'] = Config::VERSION_ORDER_EXECUTION_TIME;
+        $configWithExecutionVersionOrder = new Config($configArray);
 
         return [
             'With the default version order' => [
                 $configWithNoVersionOrder,
                 ' Status  <info>[Migration ID]</info>  Started              Finished             Migration Name '
             ],
-            'With the creation-time version order' => [
-                $configWithCreationTimeVersionOrder,
+            'With the creation version order' => [
+                $configWithCreationVersionOrder,
                 ' Status  <info>[Migration ID]</info>  Started              Finished             Migration Name '
             ],
-            'With the start-time version order' => [
-                $configWithStartTimeVersionOrder,
+            'With the execution version order' => [
+                $configWithExecutionVersionOrder,
                 ' Status  Migration ID    <info>[Started          ]</info>  Finished             Migration Name '
             ]
         ];
@@ -595,12 +595,12 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
     
     /**
-     * Test that rollbacking to version by start time chooses the correct
+     * Test that rollbacking to version by execution time chooses the correct
      * migration to point to.
      *
-     * @dataProvider rollbackToVersionByStartTimeDataProvider
+     * @dataProvider rollbackToVersionByExecutionTimeDataProvider
      */
-    public function testRollbackToVersionByStartTime($availableRollbacks, $version, $expectedOutput)
+    public function testRollbackToVersionByExecutionTime($availableRollbacks, $version, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
@@ -608,8 +608,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
-        // set the manager's config version order to start-time
-        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_START_TIME);
+        // set the manager's config version order to execution time
+        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv', $version);
         rewind($this->manager->getOutput()->getStream());
@@ -629,12 +629,12 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
     
     /**
-     * Test that rollbacking to date by start time chooses the correct
+     * Test that rollbacking to date by execution time chooses the correct
      * migration to point to.
      *
-     * @dataProvider rollbackToDateByStartTimeDataProvider
+     * @dataProvider rollbackToDateByExecutionTimeDataProvider
      */
-    public function testRollbackToDateByStartTime($availableRollbacks, $date, $expectedOutput)
+    public function testRollbackToDateByExecutionTime($availableRollbacks, $date, $expectedOutput)
     {
         // stub environment
         $envStub = $this->getMock('\Phinx\Migration\Manager\Environment', array(), array('mockenv', array()));
@@ -642,8 +642,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getVersionLog')
             ->will($this->returnValue($availableRollbacks));
 
-        // set the manager's config version order to start-time
-        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_START_TIME);
+        // set the manager's config version order to execution time
+        $this->manager->getConfig()->setVersionOrder(\Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME);
         $this->manager->setEnvironments(array('mockenv' => $envStub));
         $this->manager->rollback('mockenv', $date, false, false);
         rewind($this->manager->getOutput()->getStream());
@@ -972,7 +972,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public function rollbackToDateByStartTimeDataProvider()
+    public function rollbackToDateByExecutionTimeDataProvider()
     {
         return array(
 
@@ -1447,7 +1447,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function rollbackToVersionByStartTimeDataProvider()
+    public function rollbackToVersionByExecutionTimeDataProvider()
     {
         return [
 
@@ -1868,13 +1868,13 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     '== 20120116183504 TestMigration2: reverted'
                 ],
             
-            'Rollback to last migration with start time version ordering - no breakpoints set' => 
+            'Rollback to last migration with execution time version ordering - no breakpoints set' => 
                 [
                     [
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120111235330 TestMigration: reverted'
                 ],
             
@@ -1889,14 +1889,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     '== 20120116183504 TestMigration2: reverted'
                 ],
             
-            'Rollback to last migration with missing last migration and start time version ordering - no breakpoints set' => 
+            'Rollback to last migration with missing last migration and execution time version ordering - no breakpoints set' => 
                 [
                     [
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120111235330 TestMigration: reverted'
                 ],
             
@@ -1933,14 +1933,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             
-            'Rollback to last migration with missing last migration and start time version ordering - breakpoint set on last non-missing executed migration' => 
+            'Rollback to last migration with missing last migration and execution time version ordering - breakpoint set on last non-missing executed migration' => 
                 [
                     [
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 0],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             
@@ -1955,14 +1955,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     '== 20120116183504 TestMigration2: reverted'
                 ],
             
-            'Rollback to last migration with missing last migration and start time version ordering - breakpoint set on missing migration' => 
+            'Rollback to last migration with missing last migration and execution time version ordering - breakpoint set on missing migration' => 
                 [
                     [
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 0],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 0],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
                     '== 20120111235330 TestMigration: reverted'
                 ],
             
@@ -1999,14 +1999,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
                     'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             
-            'Rollback to last migration with missing last migration and start time version ordering - breakpoint set on all migrations' => 
+            'Rollback to last migration with missing last migration and execution time version ordering - breakpoint set on all migrations' => 
                 [
                     [
                         '20120116183504' => ['version' => '20120116183504', 'start_time' => '2012-01-10 18:35:04', 'breakpoint' => 1],
                         '20120111235330' => ['version' => '20120111235330', 'start_time' => '2012-01-12 23:53:30', 'breakpoint' => 1],
                         '20130101225232' => ['version' => '20130101225232', 'start_time' => '2013-01-01 22:52:32', 'breakpoint' => 1],
                     ],
-                    \Phinx\Config\Config::VERSION_ORDER_START_TIME,
+                    \Phinx\Config\Config::VERSION_ORDER_EXECUTION_TIME,
                     'Breakpoint reached. Further rollbacks inhibited.'
                 ],
             ];


### PR DESCRIPTION
A new Configuration option named `version_order` was added. Its possible values are:
- `creation` (the default): causes the Rollback and Status commands to order the executed migrations by their Creation Times (aka Migration IDs or Names).
- `execution`: causes the Rollback and Status commands to order the executed migrations by their Execution Times (aka Start Times).

This means that when invoking the Rollback command:
- With an `execution` version order, the last executed migration will be rollbacked.
- With an `execution` version order and a `-d (date)` option, the migration start times will be used to determine the target version to rollback to. In other words, all migrations which were executed after that date will be rollbacked.
- With an `execution` version order and a `-t (target version)` option, all migrations which were executed after the target version was executed will be rollbacked.

In terms of testing:
- The old `testRollbacksByDate` test was renamed to `testRollbackToDateTime` and turned into a unit test, ensuring the `rollback` method is called with the right target version. A new `testRollback` was added which ensures the correct output of the rollback operation (as was being done in the old `testRollbacksByDate` test).
- More test cases were added.
- General test improvements were done (like adding the expected arguments to the underlying Manager calls in `RollbackTest` and `StatusTest`.

Other notes:
- The old `rollback` and `rollbackToDateTime` methods were merged into a single `rollback` method that handles all cases and version orders.
- This PR replaces https://github.com/robmorgan/phinx/pull/926.