### PR TITLE
Do not allow the start_time to be updated when setting a breakpoint

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,8 @@
-<phpunit bootstrap="./tests/phpunit-bootstrap.php">
+<phpunit
+        bootstrap="./tests/phpunit-bootstrap.php"
+        colors="true"
+        columns="max"
+>
 
     <!--
     * This section defines configuration for running the Phinx unit tests. Some tests

--- a/src/Phinx/Db/Adapter/PdoAdapter.php
+++ b/src/Phinx/Db/Adapter/PdoAdapter.php
@@ -461,13 +461,14 @@ abstract class PdoAdapter implements AdapterInterface
     {
         $this->query(
             sprintf(
-                'UPDATE %1$s SET %2$s = CASE %2$s WHEN %3$s THEN %4$s ELSE %3$s END WHERE %5$s = \'%6$s\';',
+                'UPDATE %1$s SET %2$s = CASE %2$s WHEN %3$s THEN %4$s ELSE %3$s END, %7$s = %7$s WHERE %5$s = \'%6$s\';',
                 $this->getSchemaTableName(),
                 $this->quoteColumnName('breakpoint'),
                 $this->castToBool(true),
                 $this->castToBool(false),
                 $this->quoteColumnName('version'),
-                $migration->getVersion()
+                $migration->getVersion(),
+                $this->quoteColumnName('start_time')
             )
         );
 
@@ -481,10 +482,11 @@ abstract class PdoAdapter implements AdapterInterface
     {
         return $this->execute(
             sprintf(
-                'UPDATE %1$s SET %2$s = %3$s WHERE %2$s <> %3$s;',
+                'UPDATE %1$s SET %2$s = %3$s, %4$s = %4$s WHERE %2$s <> %3$s;',
                 $this->getSchemaTableName(),
                 $this->quoteColumnName('breakpoint'),
-                $this->castToBool(false)
+                $this->castToBool(false),
+                $this->quoteColumnName('start_time')
             )
         );
     }

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -820,12 +820,31 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->manager->setConfig($config);
         $this->manager->migrate('production');
 
+        $versions = $this->manager->getEnvironment('production')->getVersionLog();
+        $lastVersion = end($versions);
+
+        // Wait until the second has changed.
+        $now = time();
+        while($now == time());
+
         // set breakpoint on most recent migration
         $this->manager->toggleBreakpoint('production', null);
 
         // ensure breakpoint is set
         $versions = $this->manager->getEnvironment('production')->getVersionLog();
-        $this->assertEquals(1, end($versions)['breakpoint']);
+        $currentVersion = end($versions);
+        $this->assertEquals(1, $currentVersion['breakpoint']);
+
+        // ensure no other data has changed.
+        foreach($lastVersion as $key => $value) {
+            if (!is_numeric($key) && $key != 'breakpoint') {
+                $this->assertEquals($value, $currentVersion[$key]);
+            }
+        }
+
+        // Wait until the second has changed.
+        $now = time();
+        while($now == time());
 
         // reset all breakpoints
         $this->manager->removeBreakpoints('production');
@@ -833,6 +852,13 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         // ensure breakpoint is not set
         $versions = $this->manager->getEnvironment('production')->getVersionLog();
         $this->assertEquals(0, end($versions)['breakpoint']);
+
+        // ensure no other data has changed.
+        foreach($lastVersion as $key => $value) {
+            if (!is_numeric($key) && $key != 'breakpoint') {
+                $this->assertEquals($value, $currentVersion[$key]);
+            }
+        }
     }
 
     public function testBreakpointWithInvalidVersion()


### PR DESCRIPTION
This is a bug fix issue #1047

@todo Amend the start_time column to NOT be automatically update when the
phinxlog row is amended.