### PR TITLE
Update install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -18,7 +18,7 @@ To install Phinx, simply require it using Composer:
 
     php composer.phar require robmorgan/phinx
 
-Create a folder in your project directory called ``migrations`` with adequate permissions.
+Create folders in your project following the structure ``db/migrations`` with adequate permissions.
 It is where your migration files will live and should be writable.
 
 Phinx can now be executed from within your project:


### PR DESCRIPTION
In  the default ``phinx.yml`` it sets up the migration folder like this:
migrations: %%PHINX_CONFIG_DIR%%/db/migrations

Having the documentation stating that the user should only create one folder called ``migrations`` on project directory might mislead the user