### PR TITLE
Fix TextWrapper (#959)

### DIFF
--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -95,12 +95,16 @@ class TextWrapper
      */
     public function getStatus($env = null)
     {
-        $command = array(
-            'status',
-            '-e' => $env ?: $this->getOption('environment'),
-            '-c' => $this->getOption('configuration'),
-            '-p' => $this->getOption('parser')
-        );
+        $command = array('status');
+        if ($env ?: $this->hasOption('environment')) {
+            $command += array('-e' => $env ?: $this->getOption('environment'));
+        }
+        if ($this->hasOption('configuration')) {
+            $command += array('-c' => $this->getOption('configuration'));
+        }
+        if ($this->hasOption('parser')) {
+            $command += array('-p' => $this->getOption('parser'));
+        }
         return $this->executeRun($command);
     }
 
@@ -112,12 +116,16 @@ class TextWrapper
      */
     public function getMigrate($env = null, $target = null)
     {
-        $command = array(
-            'migrate',
-            '-e' => $env ?: $this->getOption('environment'),
-            '-c' => $this->getOption('configuration'),
-            '-p' => $this->getOption('parser')
-        );
+        $command = array('migrate');
+        if ($env ?: $this->hasOption('environment')) {
+            $command += array('-e' => $env ?: $this->getOption('environment'));
+        }
+        if ($this->hasOption('configuration')) {
+            $command += array('-c' => $this->getOption('configuration'));
+        }
+        if ($this->hasOption('parser')) {
+            $command += array('-p' => $this->getOption('parser'));
+        }
         if ($target) {
             $command += array('-t' => $target);
         }
@@ -133,12 +141,16 @@ class TextWrapper
      */
     public function getSeed($env = null, $target = null, $seed = null)
     {
-        $command = array (
-            'seed:run',
-            '-e' => $env?: $this->getOption('environment'),
-            '-c' => $this->getOption('configuration'),
-            '-p' => $this->getOption('parser')
-        );
+        $command = array ('seed:run');
+        if ($env ?: $this->hasOption('environment')) {
+            $command += array('-e' => $env ?: $this->getOption('environment'));
+        }
+        if ($this->hasOption('configuration')) {
+            $command += array('-c' => $this->getOption('configuration'));
+        }
+        if ($this->hasOption('parser')) {
+            $command += array('-p' => $this->getOption('parser'));
+        }
         if ($target) {
             $command += array('-t' => $target);
         }
@@ -157,18 +169,33 @@ class TextWrapper
      */
     public function getRollback($env = null, $target = null)
     {
-        $command = array(
-            'rollback',
-            '-e' => $env ?: $this->getOption('environment'),
-            '-c' => $this->getOption('configuration'),
-            '-p' => $this->getOption('parser')
-        );
+        $command = array('rollback');
+        if ($env ?: $this->hasOption('environment')) {
+            $command += array('-e' => $env ?: $this->getOption('environment'));
+        }
+        if ($this->hasOption('configuration')) {
+            $command += array('-c' => $this->getOption('configuration'));
+        }
+        if ($this->hasOption('parser')) {
+            $command += array('-p' => $this->getOption('parser'));
+        }
         if (isset($target)) {
             // Need to use isset() with rollback, because -t0 is a valid option!
             // See http://docs.phinx.org/en/latest/commands.html#the-rollback-command
             $command += array('-t' => $target);
         }
         return $this->executeRun($command);
+    }
+
+    /**
+     * Check option from options array
+     *
+     * @param  string $key
+     * @return bool
+     */
+    protected function hasOption($key)
+    {
+        return isset($this->options[$key]);
     }
 
     /**

--- a/src/Phinx/Wrapper/TextWrapper.php
+++ b/src/Phinx/Wrapper/TextWrapper.php
@@ -60,10 +60,6 @@ class TextWrapper
      */
     public function __construct(PhinxApplication $app, array $options = array())
     {
-        $options += array(
-            'environment' => 'development',
-        );
-
         $this->app = $app;
         $this->options = $options;
     }


### PR DESCRIPTION
Fix: #959 

Call parameters '-e', '-c' and '-p' only when they have a value.
Also remove default environment. Running without environment is handled by the commands itself:
https://github.com/robmorgan/phinx/blob/master/src/Phinx/Console/Command/Status.php#L76
https://github.com/robmorgan/phinx/blob/master/src/Phinx/Console/Command/Migrate.php#L79
https://github.com/robmorgan/phinx/blob/master/src/Phinx/Console/Command/Rollback.php#L92
https://github.com/robmorgan/phinx/blob/master/src/Phinx/Console/Command/SeedRun.php#L77