### PR TITLE
Update Input- and OutputInterface on cached Manager

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -285,6 +285,10 @@ abstract class AbstractCommand extends Command
         if (null === $this->getManager()) {
             $manager = new Manager($this->getConfig(), $input, $output);
             $this->setManager($manager);
+        } else {
+            $manager = $this->getManager();
+            $manager->setInput($input);
+            $manager->setOutput($output);
         }
     }
 


### PR DESCRIPTION
Fix: #960 
The commands get a fresh InputInterface and OutputInterface Instance for each time, the command runs. But the commands cache the Manager instance, which gets a reference to the Input/OutputInterface on construction. So when the command runs a second time, they get fresh Input/OutputInterfaces but uses the cached Manager Instance with reference to old Input/OutputInterface Instances.
This PR updates the Input and OutputInterface of the cached Manager to the Input/OutputInterface of the current command run. (See #960 comment for more details)