### PR TITLE
Fix rollback on only one migration

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -455,7 +455,7 @@ class Manager
         if (null === $target) {
             // Get the migration before the last run migration
             $prev = count($executedVersionCreationTimes) - 2;
-            $target = $prev >= 0 ? $executedVersionCreationTimes[$prev] : $executedVersionCreationTimes[0];
+            $target = $prev >= 0 ? $executedVersionCreationTimes[$prev] : 0;
         }
 
         // If the target must match a version, check the target version exists

--- a/tests/Phinx/Migration/ManagerTest.php
+++ b/tests/Phinx/Migration/ManagerTest.php
@@ -728,6 +728,9 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $this->manager->rollback('mockenv');
         rewind($this->manager->getOutput()->getStream());
         $output = stream_get_contents($this->manager->getOutput()->getStream());
+        $this->assertContains('== 20120111235330 TestMigration: reverting', $output);
+        $this->assertContains('== 20120111235330 TestMigration: reverted', $output);
+        $this->assertNotContains('No migrations to rollback', $output);
         $this->assertNotContains('Undefined offset: -1', $output);
     }
 


### PR DESCRIPTION
Fix #1059

I think error comes with this commit: https://github.com/robmorgan/phinx/commit/bba44b381fef9756c1d2f5a6c65ddc6757e7f6bb
If only only migration is left the first migration is selected as target instead of 0. So nothing is done.

I found a test case for this, but don't know why the test does not work:
https://github.com/robmorgan/phinx/blob/master/tests/Phinx/Migration/ManagerTest.php#L712