### PR TITLE
Allowing postgres function in default column values

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -918,7 +918,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function getDefaultValueDefinition($default)
     {
-        if (is_string($default) && 'CURRENT_TIMESTAMP' !== $default) {
+        if (is_string($default) && !$this->isDbFunctionName($default)) {
             $default = $this->getConnection()->quote($default);
         } elseif (is_bool($default)) {
             $default = $this->castToBool($default);
@@ -1176,6 +1176,17 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
 
         $baseType = $matches[1];
         return in_array($baseType, $this->getColumnTypes());
+    }
+
+    /**
+     * Determine if a string is a database function name.
+     *
+     * @param string $string
+     * @return boolean
+     */
+    private function isDbFunctionName($string = '')
+    {
+        return 'CURRENT_TIMESTAMP' === $string || preg_match('/.*\(.*\)/', $string);
     }
 
     /**

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -294,6 +294,25 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * Sets an arbitrary Postgres function as the default column value.
+     */
+    public function testAddColumnWithDefaultFunction()
+    {
+        $defaultFunctionName = 'chr(65)';
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->save();
+        $table->addColumn('default_function', 'string', array('default' => $defaultFunctionName))
+            ->save();
+        $columns = $this->adapter->getColumns('table1');
+        foreach ($columns as $column) {
+            if ($column->getName() == 'default_function') {
+                $this->assertNotNull($column->getDefault());
+                $this->assertEquals($defaultFunctionName, $column->getDefault());
+            }
+        }
+    }
+
     public function testAddDecimalWithPrecisionAndScale()
     {
         $table = new \Phinx\Db\Table('table1', array(), $this->adapter);


### PR DESCRIPTION
Addresses but #539.

I added a method to check whether the default column value is a postgres function (either `CURRENT_TIMESTAMP` or the regex that tests for function name.

I'll admit that my method of determining whether or not the Postgres function is valid is simple, but it works and doesn't break anything.

I have not used Phinx with MySQL or other db's, so I'm not sure if this problem extends to those.