### PR TITLE
Added ability to inject any custom  entries other than environments

### DIFF
--- a/src/Phinx/Config/Config.php
+++ b/src/Phinx/Config/Config.php
@@ -38,6 +38,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class Config implements ConfigInterface
 {
+	const CONFIG_ENVIRONMENTS = 'environments';
     /**
      * @var array
      */
@@ -154,6 +155,12 @@ class Config implements ConfigInterface
                 $environments[$name]['default_migration_table'] =
                     $this->values['environments']['default_migration_table'];
             }
+			// inject any other custom $config entries outside of the $config['environments'] entry
+			foreach ($this->values as $key => $value) {
+				if ($key !== self::CONFIG_ENVIRONMENTS) {
+					$environments[$name][$key] = $this->values[$key];
+				}
+			}
 
             return $environments[$name];
         }


### PR DESCRIPTION
### DESCRIPTION
Currently if you need to add any custom $config entries in Phinx you need to add it to the $config['environment'] for each company if you want to access it in your migration.  This PR provides the ability to inject any other custom 1 time $config entries into the $environments object for each company as it is running

### Proposed Changes
- Add a simple foreach loop to pick up all other $config entries other than the $config['environment'] entries