### PR TITLE
make create command output copy-paste friendly

### DIFF
--- a/src/Phinx/Console/Command/Create.php
+++ b/src/Phinx/Console/Command/Create.php
@@ -95,7 +95,7 @@ class Create extends AbstractCommand
 
     /**
      * Returns the migration path to create the migration in.
-     * 
+     *
      * @param InputInterface $input
      * @param OutputInterface $output
      * @return mixed
@@ -303,6 +303,6 @@ class Create extends AbstractCommand
             $output->writeln('<info>using default template</info>');
         }
 
-        $output->writeln('<info>created</info> ' . str_replace(getcwd(), '', $filePath));
+        $output->writeln('<info>created</info> ' . str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $filePath));
     }
 }


### PR DESCRIPTION
before:

```
➔ ./vendor/bin/phinx create InitialData
Phinx by Rob Morgan - https://phinx.org. version 0.8.0

using config file ./phinx.php
using config parser php
using migration paths 
 - /tmp/jura/db/migrations
using migration base class Phinx\Migration\AbstractMigration
using default template
created /db/migrations/20170428180919_initial_data.php

➔ git add /db/migrations/20170428180919_initial_data.php
fatal: Could not switch to '/db/': No such file or directory

➔
```

after:
```
➔ ./vendor/bin/phinx create InitialData
Phinx by Rob Morgan - https://phinx.org. version 0.8.0

using config file ./phinx.php
using config parser php
using migration paths 
 - /tmp/jura/db/migrations
using migration base class Phinx\Migration\AbstractMigration
using default template
created db/migrations/20170428180919_initial_data.php

➔ git add db/migrations/20170428180919_initial_data.php

➔
```