### PR TITLE
fixed miss method and return type error

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterWrapper.php
+++ b/src/Phinx/Db/Adapter/AdapterWrapper.php
@@ -356,6 +356,14 @@ abstract class AdapterWrapper implements AdapterInterface, WrapperInterface
     /**
      * {@inheritdoc}
      */
+    public function truncateTable($tableName)
+    {
+        $this->getAdapter()->truncateTable($tableName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getColumns($tableName)
     {
         return $this->getAdapter()->getColumns($tableName);

--- a/src/Phinx/Db/Adapter/TablePrefixAdapter.php
+++ b/src/Phinx/Db/Adapter/TablePrefixAdapter.php
@@ -102,7 +102,7 @@ class TablePrefixAdapter extends AdapterWrapper
     public function truncateTable($tableName)
     {
         $adapterTableName = $this->getAdapterTableName($tableName);
-        return parent::truncateTable($adapterTableName);
+        parent::truncateTable($adapterTableName);
     }
 
     /**


### PR DESCRIPTION
use the table_prefix option, i found an error.

$table = $this->table('user');
$table->truncate();

PHP Fatal error: Uncaught Error: Cannot call abstract method Phinx\Db\Adapter\AdapterInterface::truncateTable()