### PR TITLE
Quote column names in the addIndex() method - Postgres

### DIFF
--- a/src/Phinx/Db/Adapter/PostgresAdapter.php
+++ b/src/Phinx/Db/Adapter/PostgresAdapter.php
@@ -1023,7 +1023,7 @@ class PostgresAdapter extends PdoAdapter implements AdapterInterface
             ($index->getType() === Index::UNIQUE ? 'UNIQUE' : ''),
             $indexName,
             $this->quoteTableName($tableName),
-            implode(',', $index->getColumns())
+            implode(',', array_map(array($this, 'quoteColumnName'), $index->getColumns()))
         );
         return $def;
     }

--- a/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
+++ b/tests/Phinx/Db/Adapter/PostgresAdapterTest.php
@@ -511,6 +511,17 @@ class PostgresAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($table->hasIndex('email'));
     }
 
+    public function testAddIndexIsCaseSensitive()
+    {
+        $table = new \Phinx\Db\Table('table1', array(), $this->adapter);
+        $table->addColumn('theEmail', 'string')
+            ->save();
+        $this->assertFalse($table->hasIndex('theEmail'));
+        $table->addIndex('theEmail')
+            ->save();
+        $this->assertTrue($table->hasIndex('theEmail'));
+    }
+
     public function testDropIndex()
     {
          // single column index


### PR DESCRIPTION
Issue similar to https://github.com/robmorgan/phinx/pull/1041

The `addIndex` method did not quote the column names, which resulted in error if one of the columns being added to the index was camel case.

Test provided.